### PR TITLE
Add downtime events and custom tooltip

### DIFF
--- a/new_project/public/index.html
+++ b/new_project/public/index.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Монитор линий</title>
+  <!-- Tailwind for quick styling -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Chart.js for graphs -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="bg-gray-100 text-gray-900 min-h-screen">
+  <div id="app" class="p-4">
+    <div class="flex flex-col md:flex-row gap-4">
+      <!-- Left column: list of lines and settings button -->
+      <div class="w-full md:w-1/4">
+        <h2 class="text-lg font-bold mb-2">Линии</h2>
+        <div id="linesList" class="flex flex-col gap-2"></div>
+        <button id="settingsBtn" class="mt-4 px-3 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded">Настройки</button>
+      </div>
+      <!-- Right column: charts -->
+      <div class="flex-1">
+        <h2 id="lineTitle" class="text-lg font-bold mb-2">Скорость</h2>
+        <div class="bg-white p-4 rounded shadow">
+          <canvas id="speedChart"></canvas>
+        </div>
+        <h2 class="text-lg font-bold mt-6 mb-2">Работа / Простой (30 дней)</h2>
+        <div class="bg-white p-4 rounded shadow">
+          <canvas id="dailyChart"></canvas>
+          <a href="/report" class="mt-4 inline-block px-3 py-2 bg-green-600 hover:bg-green-700 text-white rounded">Скачать отчёт за 30 дней</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    let currentLine = null;
+    let speedChart = null;
+    let dailyChart = null;
+    // Holds downtime events per day for custom tooltip
+    let dailyEvents = [];
+
+    // Create charts on first load
+    function createCharts() {
+      const ctx1 = document.getElementById('speedChart').getContext('2d');
+      speedChart = new Chart(ctx1, {
+        type: 'line',
+        data: {
+          labels: [],
+          datasets: [
+            {
+              label: 'Скорость (см/мин)',
+              data: [],
+              borderColor: '#2563eb',
+              backgroundColor: 'rgba(37, 99, 235, 0.2)',
+              pointRadius: 0,
+              fill: true,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: {
+            x: { display: false },
+            y: {
+              beginAtZero: true,
+              title: { display: true, text: 'см/мин' },
+            },
+          },
+          plugins: {
+            legend: { display: false },
+          },
+        },
+      });
+      const ctx2 = document.getElementById('dailyChart').getContext('2d');
+      dailyChart = new Chart(ctx2, {
+        type: 'bar',
+        data: {
+          labels: [],
+          datasets: [
+            {
+              label: 'Работа (ч)',
+              data: [],
+              backgroundColor: '#16a34a',
+            },
+            {
+              label: 'Простой (ч)',
+              data: [],
+              backgroundColor: '#dc2626',
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: {
+            x: { stacked: true },
+            y: {
+              stacked: true,
+              beginAtZero: true,
+              title: { display: true, text: 'Часы' },
+            },
+          },
+          plugins: {
+            tooltip: {
+              callbacks: {
+                label: (ctx) => `${ctx.dataset.label}: ${ctx.formattedValue} ч`,
+                afterBody: (items) => {
+                  const idx = items[0].dataIndex;
+                  const evs = dailyEvents[idx] || [];
+                  if (!evs.length) return ['Нет простоев'];
+                  const lines = [];
+                  evs.forEach((ev) => {
+                    const s = new Date(ev.start).toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' });
+                    const e = new Date(ev.end).toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' });
+                    const durMin = Math.round((new Date(ev.end) - new Date(ev.start)) / 60000);
+                    const h = Math.floor(durMin / 60);
+                    const m = durMin % 60;
+                    const durStr = h ? `${h}ч ${m}м` : `${m}м`;
+                    lines.push(`Запуск: ${s}`);
+                    lines.push(`Остановка: ${e}`);
+                    lines.push(`Простой: ${durStr}`);
+                    lines.push('');
+                  });
+                  lines.pop();
+                  return lines;
+                },
+              },
+            },
+          },
+        },
+      });
+    }
+
+    // Load the current status for all lines and populate the list
+    async function loadStatus() {
+      try {
+        const res = await fetch('/status');
+        const lines = await res.json();
+        const container = document.getElementById('linesList');
+        container.innerHTML = '';
+        lines.forEach((item) => {
+          const div = document.createElement('div');
+          div.className = 'p-2 bg-white rounded shadow flex justify-between items-center cursor-pointer';
+          div.dataset.lineId = item.lineId;
+          const name = item.displayName || item.lineId;
+          const stateLabel = item.stateLabel;
+          const speed = (item.speed && !isNaN(item.speed)) ? item.speed.toFixed(1) : '-';
+          const product = item.product || '';
+          div.innerHTML = `
+            <div>
+              <div class="font-semibold">${name}</div>
+              <div class="text-sm text-gray-500">${stateLabel}</div>
+              <div class="text-xs text-gray-400">Изделие: ${product || '-'}</div>
+            </div>
+            <div class="text-right">
+              <div class="font-mono">${speed}</div>
+            </div>
+          `;
+          div.addEventListener('click', () => {
+            selectLine(item.lineId);
+          });
+          if (currentLine === null) {
+            currentLine = item.lineId;
+          }
+          container.appendChild(div);
+        });
+        // Highlight the selected line
+        Array.from(container.children).forEach((child) => {
+          child.classList.remove('border', 'border-blue-500');
+          if (child.dataset.lineId === currentLine) {
+            child.classList.add('border', 'border-blue-500');
+          }
+        });
+      } catch (e) {
+        console.error('loadStatus', e);
+      }
+    }
+
+    // Change the selected line and refresh charts
+    async function selectLine(lineId) {
+      currentLine = lineId;
+      await updateCharts();
+      // update highlight
+      const container = document.getElementById('linesList');
+      Array.from(container.children).forEach((child) => {
+        child.classList.remove('border', 'border-blue-500');
+        if (child.dataset.lineId === lineId) {
+          child.classList.add('border', 'border-blue-500');
+        }
+      });
+    }
+
+    // Fetch chart data for the current line and update both charts
+    async function updateCharts() {
+      if (!currentLine) return;
+      try {
+        const res = await fetch('/chartdata/' + currentLine);
+        const data = await res.json();
+        // Speed chart
+        speedChart.data.labels = data.speed.labels;
+        speedChart.data.datasets[0].data = data.speed.data;
+        speedChart.update();
+        // Daily chart
+        dailyEvents = data.status.events || [];
+        dailyChart.data.labels = data.status.labels;
+        dailyChart.data.datasets[0].data = data.status.work;
+        dailyChart.data.datasets[1].data = data.status.down;
+        dailyChart.update();
+        document.getElementById('lineTitle').textContent = `${data.status.lineName || currentLine} — скорость`;
+      } catch (e) {
+        console.error('updateCharts', e);
+      }
+    }
+
+    // Periodically refresh status and charts
+    async function periodic() {
+      await loadStatus();
+      await updateCharts();
+      setTimeout(periodic, 15000);
+    }
+
+    window.addEventListener('DOMContentLoaded', () => {
+      createCharts();
+      loadStatus().then(() => {
+        selectLine(currentLine);
+      });
+      periodic();
+      document.getElementById('settingsBtn').addEventListener('click', () => {
+        window.location.href = '/settings';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/new_project/server.js
+++ b/new_project/server.js
@@ -1,0 +1,745 @@
+/*
+ * server.js
+ *
+ * Main entry point for the clean extrusion monitor.  This file
+ * implements a simple REST API for ingesting pulse data, retrieving
+ * smoothed speeds and uptime statistics, generating Excel reports and
+ * configuring the smoothing parameters.  The application exposes a
+ * minimal user interface in the `public/` directory and protects
+ * access behind a login page.  A separate password is required to
+ * access the settings page.
+ */
+
+const express = require('express');
+const session = require('express-session');
+const bcrypt = require('bcrypt');
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+const fs = require('fs');
+const ExcelJS = require('exceljs');
+const { username, passwordHash } = require('./config');
+const { Agent } = require('./smartAgent');
+
+// -----------------------------------------------------------------------------
+// Configuration loading/saving
+//
+// Runtime settings (smoothing parameters, line names, etc.) are stored in
+// JSON format in config.json.  The settings may be modified at runtime
+// through the /settings API.  These helper functions load and persist
+// the settings atomically.  If the file does not exist, sensible
+// defaults are returned based on the committed version of config.json.
+
+const SETTINGS_PATH = path.join(__dirname, 'config.json');
+
+/**
+ * Load settings from disk.  If the settings file does not exist the
+ * committed defaults are returned.
+ *
+ * @returns {Object} Parsed settings.
+ */
+function loadSettings() {
+  try {
+    const raw = fs.readFileSync(SETTINGS_PATH, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    // Fall back to the committed defaults.  Using require ensures the
+    // default file is read relative to this module and cached for the
+    // lifetime of the process.
+    // eslint-disable-next-line import/no-dynamic-require
+    const defaults = require('./config.json');
+    return Object.assign({}, defaults);
+  }
+}
+
+/**
+ * Persist settings to disk.  The file is overwritten atomically to
+ * avoid corruption.
+ *
+ * @param {Object} obj Settings to save.
+ */
+function saveSettings(obj) {
+  fs.writeFileSync(SETTINGS_PATH, JSON.stringify(obj, null, 2));
+}
+
+// Load the initial settings into memory.  These values will be
+// propagated into the smoothing agent and subsequently updated via the
+// /settings API.
+let settings = loadSettings();
+
+// -----------------------------------------------------------------------------
+// Database setup
+//
+// All runtime state (status flags, event logs and minute aggregates) are
+// persisted in an SQLite database in the `data/` directory.  The
+// directory is created on startup if it does not exist.  Basic tables
+// are initialised here; more specialised tables (minute_stats) are
+// created by the smartAgent.
+
+const DATA_DIR = path.join(__dirname, 'data');
+if (!fs.existsSync(DATA_DIR)) {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+}
+const db = new sqlite3.Database(path.join(DATA_DIR, 'data.db'));
+
+// Create the core tables.  `status` tracks the current RUN/STOP
+// information per line and the time of the last packet; `status_log`
+// records state changes; `pulses` stores raw packet data for
+// completeness (currently unused by the front‑end).
+db.serialize(() => {
+  db.run(
+    `CREATE TABLE IF NOT EXISTS status (
+      lineId TEXT PRIMARY KEY,
+      isRunning INTEGER DEFAULT 0,
+      lastPulseTime INTEGER DEFAULT 0,
+      lastPacketTime INTEGER DEFAULT 0
+    )`
+  );
+  db.run(
+    `CREATE TABLE IF NOT EXISTS status_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      lineId TEXT,
+      timestamp INTEGER,
+      isRunning INTEGER
+    )`
+  );
+  db.run(
+    `CREATE TABLE IF NOT EXISTS pulses (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      lineId TEXT,
+      pulses INTEGER,
+      duration INTEGER,
+      timestamp INTEGER
+    )`
+  );
+  // Seed the 13 lines if they do not already exist.  Each line will
+  // persist even if disabled in the settings to ensure the UI shows
+  // inactive lines as "нет данных".
+  const lines = Array.from({ length: 13 }, (_, i) => `line${i + 1}`);
+  lines.forEach((lineId) => {
+    db.get(
+      `SELECT lineId FROM status WHERE lineId=?`,
+      [lineId],
+      (err, row) => {
+        if (err) return;
+        if (!row) {
+          db.run(
+            `INSERT INTO status(lineId,isRunning,lastPulseTime,lastPacketTime) VALUES (?,?,?,?)`,
+            [lineId, 0, 0, 0]
+          );
+        }
+      }
+    );
+  });
+});
+
+// Instantiate the smoothing agent.  The agent maintains its own
+// in‑memory buffers and writes minute aggregates to the database via
+// minute_stats.  Whenever the settings are updated the agent will be
+// notified by calling `updateSettings()`.
+const agent = new Agent(db, settings);
+
+// -----------------------------------------------------------------------------
+// Express application
+//
+// The API and UI are served by a single Express instance.  Sessions are
+// used to protect access to the dashboard and settings; login is
+// required for all routes except a handful of public endpoints.
+
+const app = express();
+app.use(express.json({ limit: '64kb' }));
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || 'extrusion-monitor-secret',
+    resave: false,
+    saveUninitialized: false,
+  })
+);
+
+/**
+ * Middleware to enforce authentication for protected routes.  Requests
+ * to the login page, static assets, the data ingestion endpoint and
+ * health endpoints are permitted without a session.
+ */
+function requireAuth(req, res, next) {
+  const openPaths = ['/login', '/public', '/data', '/healthz', '/time'];
+  if (openPaths.some((p) => req.path === p || req.path.startsWith(p + '/'))) {
+    return next();
+  }
+  if (req.session && req.session.user === username) {
+    return next();
+  }
+  return res.redirect('/login');
+}
+
+// -----------------------------------------------------------------------------
+// Authentication routes
+
+app.get('/login', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'login.html'));
+});
+
+app.post(
+  '/login',
+  express.urlencoded({ extended: true }),
+  async (req, res) => {
+    try {
+      const { username: u, password, remember } = req.body || {};
+      if (u === username && (await bcrypt.compare(String(password || ''), passwordHash))) {
+        req.session.user = username;
+        if (remember) {
+          req.session.cookie.maxAge = 30 * 86400 * 1000; // 30 days
+        }
+        return res.redirect('/');
+      }
+    } catch (e) {
+      console.error('login error', e);
+    }
+    res.status(401).send('Unauthorized');
+  }
+);
+
+// Apply authentication middleware
+app.use(requireAuth);
+
+// -----------------------------------------------------------------------------
+// Static files
+
+// Serve all files under public/ at /public/ so that CSS and JS
+// dependencies can be loaded directly.
+app.use('/public', express.static(path.join(__dirname, 'public')));
+
+// The root of the application serves the dashboard.  Since
+// requireAuth runs before this route, users will be redirected to
+// /login if they are not authenticated.
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+// -----------------------------------------------------------------------------
+// Data ingestion
+
+// POST /data accepts packets from the ESP32 containing pulses, the
+// duration of the sampling interval and an optional timestamp.
+// Example packet: { "lineId": "line1", "pulses": 42, "duration": 10000, "ts": 1692922200 }
+// If no timestamp is provided the current server time is used.  The
+// server stores the raw packet, updates its smoothing buffers and
+// records any RUN/STOP transitions to the event log.
+app.post('/data', (req, res) => {
+  try {
+    const { lineId, pulses, duration, ts } = req.body || {};
+    const id = String(lineId || '').trim();
+    const p = Number(pulses);
+    const dur = Number(duration);
+    if (!id || !Number.isFinite(p) || !Number.isFinite(dur) || dur <= 0) {
+      return res.status(400).json({ error: 'invalid payload' });
+    }
+    // Normalise timestamp inside the agent.  We insert the raw packet
+    // into pulses purely for archival purposes; the ingestion logic
+    // itself does not read from this table.
+    const pktTs = ts;
+    db.run(
+      `INSERT INTO pulses(lineId,pulses,duration,timestamp) VALUES (?,?,?,?)`,
+      [id, p, dur, Math.floor((ts && ts > 1e12 ? ts / 1000 : ts) || Date.now() / 1000)],
+      () => {}
+    );
+    // Ensure the line exists in the status table.  If it is a new
+    // identifier it will be inserted with default values.
+    db.get(
+      `SELECT lineId,isRunning FROM status WHERE lineId=?`,
+      [id],
+      (err, row) => {
+        if (err) {
+          console.error('status fetch', err);
+          return res.status(500).json({ error: 'db' });
+        }
+        if (!row) {
+          db.run(
+            `INSERT INTO status(lineId,isRunning,lastPulseTime,lastPacketTime) VALUES (?,?,?,?)`,
+            [id, 0, 0, 0],
+            () => {}
+          );
+        }
+        // Feed the packet into the smoothing agent.  The agent
+        // determines whether a state change occurred and returns
+        // smoothed speed.
+        const { smoothedSpeed, stateChanged, newState } = agent.ingest(id, {
+          pulses: p,
+          duration: dur,
+          ts: pktTs,
+        });
+        const nowSec = Math.floor(Date.now() / 1000);
+        // Update the status table's timing fields.  lastPacketTime is
+        // always updated; lastPulseTime is updated only when pulses>0.
+        const updates = [];
+        const params = [];
+        updates.push('lastPacketTime=?');
+        params.push(nowSec);
+        if (p > 0) {
+          updates.push('lastPulseTime=?');
+          params.push(nowSec);
+        }
+        if (stateChanged) {
+          updates.push('isRunning=?');
+          params.push(newState);
+        }
+        params.push(id);
+        db.run(
+          `UPDATE status SET ${updates.join(', ')} WHERE lineId=?`,
+          params,
+          () => {
+            if (stateChanged) {
+              db.run(
+                `INSERT INTO status_log(lineId,timestamp,isRunning) VALUES (?,?,?)`,
+                [id, nowSec, newState],
+                () => {}
+              );
+            }
+            res.json({ ok: true });
+          }
+        );
+      }
+    );
+  } catch (e) {
+    console.error('/data error', e);
+    res.status(500).json({ error: 'server' });
+  }
+});
+
+// -----------------------------------------------------------------------------
+// Status endpoint
+
+// GET /status returns the current state of all 13 lines.  Each entry
+// contains the lineId, a human‑friendly displayName, the smoothed
+// speed and a label describing whether the line is running, stopped
+// or has no data.  Lines that have never received a packet are
+// reported as having no data.
+app.get('/status', (req, res) => {
+  const lines = Array.from({ length: 13 }, (_, i) => `line${i + 1}`);
+  db.all(`SELECT lineId,isRunning,lastPulseTime,lastPacketTime FROM status ORDER BY lineId ASC`, (err, rows) => {
+    if (err) {
+      console.error('/status db', err);
+      return res.json([]);
+    }
+    const nowSec = Math.floor(Date.now() / 1000);
+    const result = [];
+    for (const id of lines) {
+      const row = rows.find((r) => r.lineId === id) || { lineId: id, isRunning: 0, lastPulseTime: 0, lastPacketTime: 0 };
+      const smoothedSpeed = agent.getSmoothedSpeed(id);
+      const isRunning = agent.getState(id);
+      // Determine whether the line is offline.  If no packet has ever
+      // been received (lastPacketTime=0) or the elapsed time since the
+      // last packet exceeds offlineTimeout we label it as having no
+      // data.  Otherwise we reflect its running/stopped state.
+      let stateLabel = 'нет данных';
+      if (row.lastPacketTime && nowSec - row.lastPacketTime <= (settings.offlineTimeout || 60)) {
+        stateLabel = isRunning ? 'Работает' : 'Остановлена';
+      }
+      const displayName = (settings.lineNames && settings.lineNames[id]) || id;
+      result.push({
+        lineId: id,
+        displayName,
+        speed: smoothedSpeed,
+        isRunning: !!isRunning,
+        lastPulseTime: row.lastPulseTime,
+        lastPacketTime: row.lastPacketTime,
+        stateLabel,
+      });
+    }
+    res.json(result);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Chart data endpoint
+
+// GET /chartdata/:lineId returns the time series for the selected line
+// along with the last 30 days of uptime/downtime statistics.  The
+// number of hours in the speed chart is determined by the current
+// settings (graphHours) and the daily aggregation uses 30 days.
+app.get('/chartdata/:lineId', (req, res) => {
+  const lineId = String(req.params.lineId || '').trim();
+  const hours = Number(settings.graphHours) || 24;
+  agent.getSeries(lineId, hours, (err1, series) => {
+    if (err1 || !series) {
+      console.error('getSeries', err1);
+      return res.status(500).json({ error: 'series' });
+    }
+    agent.getDailyWorkIdle(lineId, 30, (err2, daily) => {
+      if (err2 || !daily) {
+        console.error('getDailyWorkIdle', err2);
+        return res.status(500).json({ error: 'daily' });
+      }
+      const lineName = (settings.lineNames && settings.lineNames[lineId]) || lineId;
+      const speed = {
+        labels: series.labels,
+        data: series.data,
+      };
+      // Convert event timestamps to ISO strings for precise tooltips on the client
+      const events = (daily.events || []).map((arr) =>
+        arr.map((e) => ({
+          start: new Date(e.start * 1000).toISOString(),
+          end: new Date(e.end * 1000).toISOString(),
+        }))
+      );
+      const status = {
+        labels: daily.labels,
+        work: daily.work,
+        down: daily.down,
+        lineName,
+        events,
+      };
+      res.json({ speed, status });
+    });
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Excel reports
+
+// GET /report generates a detailed Excel report including per‑event
+// breakdowns of running and stopped segments as well as a summary
+// sheet.  The implementation mirrors the old system but uses the
+// merged segments logic to ignore short stops and runs.  The report
+// spans the last 30 days by default or can be constrained via
+// ?from=YYYY-MM-DD&to=YYYY-MM-DD.  Dates are interpreted in the
+// server's local timezone.
+app.get('/report', async (req, res) => {
+  try {
+    // Parse optional from/to parameters.  If omitted the last 30 days
+    // are included.  Convert ISO dates to UNIX timestamps.
+    const parseDate = (s) => {
+      if (!s) return null;
+      const d = new Date(s);
+      if (isNaN(d.getTime())) return null;
+      return Math.floor(d.getTime() / 1000);
+    };
+    const nowSec = Math.floor(Date.now() / 1000);
+    const toTs = parseDate(req.query.to) || nowSec;
+    const fromTs = parseDate(req.query.from) || toTs - 30 * 86400;
+    const wb = new ExcelJS.Workbook();
+    const summary = wb.addWorksheet('Сводка 30 дней');
+    summary.columns = [
+      { header: 'Линия', key: 'line', width: 12 },
+      { header: 'Работа, ч', key: 'up', width: 14 },
+      { header: 'Простой, ч', key: 'down', width: 14 },
+      { header: '% простоя', key: 'pct', width: 12 },
+    ];
+    const lines = Array.from({ length: 13 }, (_, i) => `line${i + 1}`);
+    for (const lineId of lines) {
+      // Build a per‑line worksheet
+      const ws = wb.addWorksheet(lineId);
+      ws.columns = [
+        { header: 'Дата', key: 'date', width: 12 },
+        { header: 'Событие', key: 'ev', width: 18 },
+        { header: 'Время', key: 'when', width: 20 },
+        { header: 'Простой, мин', key: 'downtime', width: 14 },
+      ];
+      // Helper to add a row to the worksheet
+      function addRow(date, ev, whenTs, extra) {
+        const whenStr = new Date(whenTs * 1000).toISOString().replace('T', ' ').substring(0, 19);
+        ws.addRow({ date, ev, when: whenStr, downtime: extra });
+      }
+      // Determine the state at fromTs
+      const initial = await new Promise((resolve) => {
+        db.get(
+          `SELECT isRunning FROM status_log WHERE lineId=? AND timestamp<? ORDER BY timestamp DESC LIMIT 1`,
+          [lineId, fromTs],
+          (err, row) => {
+            resolve(row ? Number(row.isRunning) : 0);
+          }
+        );
+      });
+      // Fetch all logs within the requested range
+      const logs = await new Promise((resolve) => {
+        db.all(
+          `SELECT timestamp,isRunning FROM status_log WHERE lineId=? AND timestamp>=? AND timestamp<=? ORDER BY timestamp ASC`,
+          [lineId, fromTs, toTs],
+          (err, rows) => {
+            resolve(rows || []);
+          }
+        );
+      });
+      // Iterate through each day between fromTs and toTs and build
+      // segments.  We'll accumulate total run/down time for the summary.
+      let totalRun = 0;
+      let totalDown = 0;
+      let prevState = initial;
+      for (let dayStart = Math.floor(fromTs / 86400) * 86400; dayStart < toTs; dayStart += 86400) {
+        const dayEnd = Math.min(dayStart + 86400, toTs);
+        const dayLabel = new Date(dayStart * 1000).toISOString().slice(0, 10);
+        // Build raw segments for this day
+        const dayEvents = logs.filter((ev) => ev.timestamp >= dayStart && ev.timestamp < dayEnd);
+        let state = prevState;
+        let segStart = dayStart;
+        const segments = [];
+        for (const ev of dayEvents) {
+          if (Number(ev.isRunning) !== state) {
+            segments.push({ start: segStart, end: ev.timestamp, state });
+            state = Number(ev.isRunning);
+            segStart = ev.timestamp;
+          }
+        }
+        segments.push({ start: segStart, end: dayEnd, state });
+        prevState = state;
+        // Merge short segments (<60s) into the opposite state
+        const merged = [];
+        for (const seg of segments) {
+          const dur = seg.end - seg.start;
+          if (seg.state === 1 && dur < 60) {
+            // short run => downtime
+            if (merged.length && merged[merged.length - 1].state === 0) {
+              merged[merged.length - 1].end = seg.end;
+            } else {
+              merged.push({ start: seg.start, end: seg.end, state: 0 });
+            }
+          } else if (seg.state === 0 && dur < 60) {
+            // short stop => uptime
+            if (merged.length && merged[merged.length - 1].state === 1) {
+              merged[merged.length - 1].end = seg.end;
+            } else {
+              merged.push({ start: seg.start, end: seg.end, state: 1 });
+            }
+          } else {
+            merged.push({ ...seg });
+          }
+        }
+        // Write merged segments to worksheet
+        for (let i = 0; i < merged.length; i++) {
+          const seg = merged[i];
+          const durMin = Math.round((seg.end - seg.start) / 60);
+          if (seg.state === 1) {
+            totalRun += seg.end - seg.start;
+            addRow(dayLabel, 'Работа', seg.start, String(durMin));
+            addRow(dayLabel, 'Остановка', seg.end, '');
+          } else {
+            totalDown += seg.end - seg.start;
+            addRow(dayLabel, 'Простой', seg.start, String(durMin));
+            if (i < merged.length - 1 && merged[i + 1].state === 1) {
+              addRow(dayLabel, 'Запуск', seg.end, '');
+            }
+          }
+        }
+      }
+      // Add a summary row for this line
+      const total = totalRun + totalDown;
+      const pct = total ? ((totalDown / total) * 100).toFixed(1) + '%' : '0.0%';
+      summary.addRow({ line: lineId, up: (totalRun / 3600).toFixed(1), down: (totalDown / 3600).toFixed(1), pct });
+    }
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', 'attachment; filename="report.xlsx"');
+    await wb.xlsx.write(res);
+    res.end();
+  } catch (e) {
+    console.error('/report error', e);
+    res.status(500).json({ error: 'report' });
+  }
+});
+
+// GET /report_clean generates a simplified 30‑day summary report using
+// the smoothing agent to compute uptime and downtime.  Each line
+// receives its own sheet and a summary is provided on the first page.
+app.get('/report_clean', async (req, res) => {
+  try {
+    const wb = new ExcelJS.Workbook();
+    const summary = wb.addWorksheet('Сводка 30 дней');
+    summary.columns = [
+      { header: 'Линия', key: 'line', width: 12 },
+      { header: 'Работа, ч', key: 'up', width: 14 },
+      { header: 'Простой, ч', key: 'down', width: 14 },
+      { header: '% простоя', key: 'pct', width: 12 },
+    ];
+    const lines = Array.from({ length: 13 }, (_, i) => `line${i + 1}`);
+    for (const lineId of lines) {
+      const sheet = wb.addWorksheet(lineId);
+      sheet.columns = [
+        { header: 'Дата', key: 'date', width: 12 },
+        { header: 'Работа, ч', key: 'up', width: 14 },
+        { header: 'Простой, ч', key: 'down', width: 14 },
+      ];
+      await new Promise((resolve) => {
+        agent.getDailyWorkIdle(lineId, 30, (err, daily) => {
+          if (!err && daily) {
+            let runTotal = 0;
+            let downTotal = 0;
+            for (let i = 0; i < daily.labels.length; i++) {
+              const date = daily.labels[i];
+              const up = daily.work[i];
+              const down = daily.down[i];
+              runTotal += up;
+              downTotal += down;
+              sheet.addRow({ date, up, down });
+            }
+            const total = runTotal + downTotal;
+            const pct = total ? ((downTotal / total) * 100).toFixed(1) + '%' : '0.0%';
+            summary.addRow({ line: lineId, up: runTotal.toFixed(1), down: downTotal.toFixed(1), pct });
+          }
+          resolve();
+        });
+      });
+    }
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', 'attachment; filename="report_30days_clean.xlsx"');
+    await wb.xlsx.write(res);
+    res.end();
+  } catch (e) {
+    console.error('/report_clean error', e);
+    res.status(500).json({ error: 'report_clean' });
+  }
+});
+
+// Convenience route used by the old UI; forwards to the simplified
+// report.  Clients can call /report/last30days directly to obtain
+// report_30days_clean.xlsx.
+app.get('/report/last30days', (req, res) => {
+  req.url = '/report_clean';
+  app._router.handle(req, res, () => {});
+});
+
+// -----------------------------------------------------------------------------
+// Settings API
+
+// GET /settings serves the settings page.  Authentication via requireAuth
+// ensures only logged in users can access it.  Authorisation for
+// editing settings is enforced in the AJAX endpoints.
+app.get('/settings', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'settings.html'));
+});
+
+// POST /settings/auth verifies the settings password.  If successful
+// the session gains a `settingsAuth` flag which is required to call
+// /settings/info and /settings/save.
+app.post('/settings/auth', (req, res) => {
+  try {
+    const { password } = req.body || {};
+    // Hard‑coded password for accessing settings.  If needed, this
+    // could be externalised into the config.  The user must change
+    // this value in the specification if they want a different
+    // password for settings.
+    const settingsPassword = '19910509';
+    if (String(password) === settingsPassword) {
+      req.session.settingsAuth = true;
+      return res.json({ ok: true });
+    }
+    return res.status(401).json({ error: 'wrong password' });
+  } catch (e) {
+    console.error('/settings/auth', e);
+    res.status(500).json({ error: 'server' });
+  }
+});
+
+// GET /settings/info returns the current settings to authenticated
+// settings users.  Without settingsAuth this endpoint returns 401.
+app.get('/settings/info', (req, res) => {
+  if (!req.session.settingsAuth) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  res.json(settings);
+});
+
+// POST /settings/save persists new settings.  The payload replaces
+// existing values; missing fields retain their previous values.  After
+// saving to disk the in‑memory settings and the agent are updated.
+app.post('/settings/save', (req, res) => {
+  if (!req.session.settingsAuth) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  try {
+    const body = req.body || {};
+    // Validate and coerce incoming values.  Fallback to existing
+    // settings when values are missing or invalid.
+    const newCfg = Object.assign({}, settings);
+    const num = (v, def) => {
+      const n = Number(v);
+      return Number.isFinite(n) && n >= 0 ? n : def;
+    };
+    newCfg.windowSec = num(body.windowSec, settings.windowSec);
+    newCfg.V_START = num(body.V_START, settings.V_START);
+    newCfg.V_STOP = num(body.V_STOP, settings.V_STOP);
+    newCfg.delayStart = num(body.delayStart, settings.delayStart);
+    newCfg.delayStop = num(body.delayStop, settings.delayStop);
+    newCfg.graphHours = num(body.graphHours, settings.graphHours);
+    newCfg.offlineTimeout = num(body.offlineTimeout, settings.offlineTimeout);
+    // Enabled lines should be an array of strings; if omitted use
+    // existing enabledLines.
+    if (Array.isArray(body.enabledLines)) {
+      newCfg.enabledLines = body.enabledLines.map((x) => String(x));
+    }
+    // lineNames is expected to be an object mapping lineId to string
+    if (body.lineNames && typeof body.lineNames === 'object') {
+      const names = {};
+      for (let i = 1; i <= 13; i++) {
+        const id = `line${i}`;
+        names[id] = String(body.lineNames[id] || settings.lineNames[id] || '');
+      }
+      newCfg.lineNames = names;
+    }
+    settings = newCfg;
+    // Persist the settings and update the agent
+    saveSettings(settings);
+    agent.updateSettings(settings);
+    res.json({ ok: true });
+  } catch (e) {
+    console.error('/settings/save', e);
+    res.status(500).json({ error: 'server' });
+  }
+});
+
+// -----------------------------------------------------------------------------
+// Miscellaneous
+
+// Health check endpoint.  Useful for container orchestration or
+// monitoring scripts.
+app.get('/healthz', (req, res) => {
+  res.json({ ok: true });
+});
+
+// Return the current server time for synchronisation or debugging.
+app.get('/time', (req, res) => {
+  res.json({ now: Math.floor(Date.now() / 1000) });
+});
+
+// -----------------------------------------------------------------------------
+// Offline watchdog
+
+// Periodically inspect each line and mark it as STOP if no packet has
+// been received within the configured offline timeout.  When a line
+// transitions from RUN to STOP as a result of the watchdog, a log
+// entry is recorded.  Note: the agent itself resets its smoothing
+// buffer in handleOffline().
+setInterval(() => {
+  const nowSec = Math.floor(Date.now() / 1000);
+  db.all(
+    `SELECT lineId,isRunning,lastPacketTime FROM status`,
+    (err, rows) => {
+      if (err || !rows) return;
+      rows.forEach((row) => {
+        const timeout = Number(settings.offlineTimeout) || 60;
+        if (row.lastPacketTime && nowSec - row.lastPacketTime > timeout) {
+          const changed = agent.handleOffline(row.lineId);
+          if (changed) {
+            // Update DB state and log the stop event
+            db.run(
+              `UPDATE status SET isRunning=0 WHERE lineId=?`,
+              [row.lineId],
+              () => {
+                db.run(
+                  `INSERT INTO status_log(lineId,timestamp,isRunning) VALUES (?,?,0)`,
+                  [row.lineId, nowSec, 0],
+                  () => {}
+                );
+              }
+            );
+          }
+        }
+      });
+    }
+  );
+}, 15000);
+
+// -----------------------------------------------------------------------------
+// Start the HTTP server
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
+app.listen(PORT, () => {
+  console.log(`HTTP server listening on port ${PORT}`);
+});

--- a/new_project/smartAgent.js
+++ b/new_project/smartAgent.js
@@ -1,0 +1,396 @@
+/*
+ * smartAgent.js
+ *
+ * A lightweight smoothing and state detection module for the extrusion
+ * monitoring system.  It ingests pulse packets from the ESP32, applies
+ * a sliding‑window average to compute a smoothed speed and determines
+ * whether each line is running or stopped using configurable thresholds
+ * and delays.  The agent also produces minute‑level speed aggregates
+ * for charting and exposes helper methods to compute daily uptime and
+ * downtime from the recorded event log.
+ */
+
+const sqlite3 = require('sqlite3').verbose();
+
+class Agent {
+  /**
+   * Construct a new Agent.
+   *
+   * @param {sqlite3.Database} db          SQLite connection used to
+   *                                       persist minute aggregates.
+   * @param {Object} settings              Initial smoothing and state
+   *                                       detection parameters.
+   */
+  constructor(db, settings) {
+    this.db = db;
+    // Copy settings so that subsequent updates don't mutate the
+    // originally passed object.
+    this.settings = Object.assign({}, settings);
+    // Per‑line state.  Each key stores an object with the following
+    // fields:
+    //   messages: array of recent packets { pulses, duration, ts }
+    //   lastPacket: timestamp of the most recent packet (seconds)
+    //   lastState: 1 for RUN, 0 for STOP
+    //   holdStart: timestamp when we began counting towards a RUN change
+    //   holdStop:  timestamp when we began counting towards a STOP change
+    //   smoothedSpeed: latest computed smoothed speed (cm/min)
+    this.lines = {};
+    // Map used to accumulate per‑minute speed aggregates before they are
+    // flushed to disk.  Keys are `${lineId}_${minuteTs}` and values
+    // contain { sum, count }.
+    this.minuteMap = {};
+    // Create the minute_stats table for storing per‑minute speeds.  We
+    // avoid creating this table inside ingest() to minimise the cost on
+    // the critical path.
+    this.db.serialize(() => {
+      this.db.run(
+        `CREATE TABLE IF NOT EXISTS minute_stats (
+          lineId TEXT,
+          ts INTEGER,
+          speed REAL,
+          PRIMARY KEY(lineId, ts)
+        )`
+      );
+    });
+    // Periodically flush stale minute aggregates to the database.  The
+    // flush interval is deliberately short so that charts show recent
+    // values without significant lag.
+    setInterval(() => this.flushMinuteData(), 10000);
+  }
+
+  /**
+   * Update the smoothing and state detection parameters at runtime.  The
+   * provided object replaces the existing settings; any missing
+   * properties retain their previous values.
+   *
+   * @param {Object} newSettings Updated settings.
+   */
+  updateSettings(newSettings) {
+    this.settings = Object.assign({}, this.settings, newSettings || {});
+  }
+
+  /**
+   * Ingest a single pulse packet.  The caller is responsible for
+   * persisting raw packet data and updating the status table.  This
+   * method updates the internal smoothing buffer, computes the
+   * smoothed speed and determines whether the line has transitioned
+   * between RUN and STOP.  It returns information about the new state
+   * so that the caller can update the database accordingly.
+   *
+   * @param {String} lineId Identifier of the monitored line.
+   * @param {Object} pkt    Packet with fields:
+   *   pulses   {Number}  Number of pulses counted in the sampling period.
+   *   duration {Number}  Duration of the sampling period in milliseconds.
+   *   ts       {Number}  Optional UNIX timestamp in seconds; if omitted
+   *                      the current time is used.
+   * @returns {Object} { smoothedSpeed, stateChanged, newState }
+   */
+  ingest(lineId, pkt) {
+    const pulses = Number(pkt.pulses) || 0;
+    const durationMs = Number(pkt.duration) || 0;
+    // Normalize timestamp: accept seconds or milliseconds.  When a
+    // millisecond epoch is provided the value will exceed 1e12.
+    let ts = Number(pkt.ts);
+    if (!ts || isNaN(ts)) ts = Math.floor(Date.now() / 1000);
+    else if (ts > 1e12) ts = Math.floor(ts / 1000);
+    const line = this.lines[lineId] || {
+      messages: [],
+      lastPacket: ts,
+      lastState: 0,
+      holdStart: 0,
+      holdStop: 0,
+      smoothedSpeed: 0,
+    };
+    this.lines[lineId] = line;
+    // Append the new packet and prune old entries outside the sliding
+    // window.  We keep the raw pulses and durations in order to
+    // compute a weighted average later on.
+    line.messages.push({ pulses, duration: durationMs, ts });
+    line.lastPacket = ts;
+    const windowSec = Number(this.settings.windowSec) || 60;
+    const cutoff = ts - windowSec;
+    line.messages = line.messages.filter(m => m.ts >= cutoff);
+    // Compute the weighted average speed.  The speed for a single
+    // packet is (pulses / durationMs) * 60000 = cm/min (since 1 pulse
+    // equals 1 cm).  To average over the window we sum all pulses and
+    // durations and apply the same formula.
+    let sumPulses = 0;
+    let sumDuration = 0;
+    for (const m of line.messages) {
+      sumPulses += m.pulses;
+      sumDuration += m.duration;
+    }
+    let smoothedSpeed = 0;
+    if (sumDuration > 0) {
+      smoothedSpeed = (sumPulses / (sumDuration / 1000)) * 60;
+    }
+    line.smoothedSpeed = smoothedSpeed;
+    // State detection.  We implement a simple hysteresis: when the
+    // smoothed speed rises above V_START and remains there for
+    // delayStart seconds the line is considered running.  When the
+    // smoothed speed falls below V_STOP and remains there for
+    // delayStop seconds it is considered stopped.  When in either
+    // state, the opposing hold timer is reset if the speed crosses
+    // back over the opposite threshold.
+    const V_START = Number(this.settings.V_START) || 0.5;
+    const V_STOP = Number(this.settings.V_STOP) || 0.3;
+    const delayStart = Number(this.settings.delayStart) || 30;
+    const delayStop = Number(this.settings.delayStop) || 30;
+    let newState = line.lastState;
+    if (line.lastState === 1) {
+      // Currently running; look for stop condition.
+      if (smoothedSpeed <= V_STOP) {
+        if (!line.holdStop) line.holdStop = ts;
+        if (ts - line.holdStop >= delayStop) {
+          newState = 0;
+          line.holdStop = 0;
+          line.holdStart = 0;
+        }
+      } else {
+        // Speed recovered; reset stop hold timer.
+        line.holdStop = 0;
+      }
+    } else {
+      // Currently stopped; look for run condition.
+      if (smoothedSpeed >= V_START) {
+        if (!line.holdStart) line.holdStart = ts;
+        if (ts - line.holdStart >= delayStart) {
+          newState = 1;
+          line.holdStart = 0;
+          line.holdStop = 0;
+        }
+      } else {
+        // Speed dropped; reset run hold timer.
+        line.holdStart = 0;
+      }
+    }
+    const stateChanged = newState !== line.lastState;
+    line.lastState = newState;
+    // Aggregate the smoothed speed per minute.  We maintain a map of
+    // aggregates keyed by `${lineId}_${minuteTs}`.  The minute
+    // timestamp is truncated to the start of the minute.  Each entry
+    // accumulates the smoothed speed and a sample count.  Later a
+    // periodic flush writes these entries to minute_stats.
+    const minuteTs = Math.floor(ts / 60) * 60;
+    const mapKey = `${lineId}_${minuteTs}`;
+    const entry = this.minuteMap[mapKey] || { sum: 0, count: 0 };
+    entry.sum += smoothedSpeed;
+    entry.count += 1;
+    this.minuteMap[mapKey] = entry;
+    return { smoothedSpeed, stateChanged, newState };
+  }
+
+  /**
+   * Flush stale minute aggregates to the database.  Aggregates older
+   * than one minute ago are written to minute_stats and removed from
+   * the in‑memory map.  This method is invoked periodically by a
+   * timer set up in the constructor.
+   */
+  flushMinuteData() {
+    const now = Math.floor(Date.now() / 1000);
+    const currentMinute = Math.floor(now / 60) * 60;
+    const keys = Object.keys(this.minuteMap);
+    for (const key of keys) {
+      const [lineId, tsStr] = key.split('_');
+      const minuteTs = parseInt(tsStr, 10);
+      // Only flush minutes older than the most recent complete minute.
+      if (minuteTs < currentMinute) {
+        const entry = this.minuteMap[key];
+        const avg = entry.count > 0 ? entry.sum / entry.count : 0;
+        this.db.run(
+          `INSERT OR REPLACE INTO minute_stats(lineId, ts, speed) VALUES (?,?,?)`,
+          [lineId, minuteTs, avg],
+          () => {}
+        );
+        delete this.minuteMap[key];
+      }
+    }
+  }
+
+  /**
+   * Reset a line when no packets have arrived for the configured
+   * offlineTimeout.  The smoothing buffer is cleared, the speed is
+   * reset to zero and the state transitions to STOP.  The caller is
+   * responsible for updating the database if a state change occurs.
+   *
+   * @param {String} lineId Identifier of the line to reset.
+   * @returns {Boolean} True if the line transitioned from RUN to STOP.
+   */
+  handleOffline(lineId) {
+    const line = this.lines[lineId];
+    if (!line) return false;
+    let changed = false;
+    // Clear the smoothing buffer and timers.
+    line.messages = [];
+    line.smoothedSpeed = 0;
+    line.holdStart = 0;
+    line.holdStop = 0;
+    if (line.lastState === 1) {
+      line.lastState = 0;
+      changed = true;
+    }
+    return changed;
+  }
+
+  /**
+   * Retrieve the latest smoothed speed for a line.  If no data has been
+   * received the speed is zero.
+   *
+   * @param {String} lineId Identifier of the line.
+   * @returns {Number} Smoothed speed (cm/min).
+   */
+  getSmoothedSpeed(lineId) {
+    const line = this.lines[lineId];
+    return line ? line.smoothedSpeed : 0;
+  }
+
+  /**
+   * Retrieve the last known state for a line.  1 represents RUN and 0
+   * represents STOP.
+   *
+   * @param {String} lineId Identifier of the line.
+   * @returns {Number} The current state.
+   */
+  getState(lineId) {
+    const line = this.lines[lineId];
+    return line ? line.lastState : 0;
+  }
+
+  /**
+   * Fetch a time series of smoothed speeds for the given number of
+   * hours.  The method reads from the minute_stats table and fills in
+   * missing minutes with null values so that Chart.js draws gaps.
+   *
+   * @param {String} lineId Identifier of the line.
+   * @param {Number} hours  Number of hours of history to return.
+   * @param {Function} cb   Callback (err, { labels, data }).
+   */
+  getSeries(lineId, hours, cb) {
+    const now = Math.floor(Date.now() / 1000);
+    const toMinute = Math.floor(now / 60) * 60;
+    const fromMinute = toMinute - hours * 3600;
+    this.db.all(
+      `SELECT ts, speed FROM minute_stats WHERE lineId=? AND ts>=? AND ts<=? ORDER BY ts ASC`,
+      [lineId, fromMinute, toMinute],
+      (err, rows) => {
+        if (err) return cb(err);
+        const map = {};
+        for (const r of rows) {
+          map[r.ts] = r.speed;
+        }
+        const labels = [];
+        const data = [];
+        for (let t = fromMinute; t <= toMinute; t += 60) {
+          labels.push(new Date(t * 1000).toISOString());
+          if (map.hasOwnProperty(t)) data.push(map[t]);
+          else data.push(null);
+        }
+        cb(null, { labels, data });
+      }
+    );
+  }
+
+  /**
+   * Compute daily uptime and downtime for a line.  The algorithm uses
+   * the status_log table to determine RUN/STOP segments and merges
+   * segments shorter than 60 seconds into the opposite state.  The
+   * returned arrays contain one entry per day, starting from the most
+   * recent day and going back `days` days.  All durations are
+   * expressed in hours with one decimal place.
+   *
+   * @param {String} lineId Identifier of the line.
+   * @param {Number} days   Number of days to return (e.g. 30).
+   * @param {Function} cb   Callback (err, { labels, work, down }).
+   */
+  getDailyWorkIdle(lineId, days, cb) {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const to = nowSec;
+    const from = to - days * 86400;
+    // Fetch logs for the relevant period and the last state before the
+    // period to determine the initial state.
+    this.db.all(
+      `SELECT timestamp, isRunning FROM status_log WHERE lineId=? AND timestamp>=? AND timestamp<=? ORDER BY timestamp ASC`,
+      [lineId, from, to],
+      (err, rows) => {
+        if (err) return cb(err);
+        this.db.get(
+          `SELECT isRunning FROM status_log WHERE lineId=? AND timestamp<? ORDER BY timestamp DESC LIMIT 1`,
+          [lineId, from],
+          (err2, lastRow) => {
+            if (err2) return cb(err2);
+            let initialState = lastRow ? Number(lastRow.isRunning) : 0;
+            const labels = [];
+            const work = [];
+            const down = [];
+            const eventsByDay = [];
+            // We'll iterate from the oldest day to the most recent so
+            // that the resulting arrays line up with ascending dates.
+            for (let d = days - 1; d >= 0; d--) {
+              const dayStart = Math.floor((to - d * 86400) / 86400) * 86400;
+              const dayEnd = dayStart + 86400;
+              const dayLogs = rows.filter(r => r.timestamp >= dayStart && r.timestamp < dayEnd);
+              // Build raw segments within this day.
+              let segState = initialState;
+              let segStart = dayStart;
+              const segments = [];
+              for (const ev of dayLogs) {
+                if (Number(ev.isRunning) !== segState) {
+                  segments.push({ start: segStart, end: ev.timestamp, state: segState });
+                  segState = Number(ev.isRunning);
+                  segStart = ev.timestamp;
+                }
+              }
+              segments.push({ start: segStart, end: dayEnd, state: segState });
+              // Update initialState for the next iteration (previous day)
+              initialState = segments.length > 0 ? segments[segments.length - 1].state : initialState;
+              // Merge short segments (<60 seconds).  Runs shorter than
+              // 60 seconds are treated as downtime; stops shorter than
+              // 60 seconds are treated as uptime.
+              const merged = [];
+              for (const seg of segments) {
+                const dur = seg.end - seg.start;
+                if (seg.state === 1 && dur < 60) {
+                  // Short run; merge into downtime
+                  if (merged.length && merged[merged.length - 1].state === 0) {
+                    merged[merged.length - 1].end = seg.end;
+                  } else {
+                    merged.push({ start: seg.start, end: seg.end, state: 0 });
+                  }
+                } else if (seg.state === 0 && dur < 60) {
+                  // Short stop; merge into uptime
+                  if (merged.length && merged[merged.length - 1].state === 1) {
+                    merged[merged.length - 1].end = seg.end;
+                  } else {
+                    merged.push({ start: seg.start, end: seg.end, state: 1 });
+                  }
+                } else {
+                  merged.push({ ...seg });
+                }
+              }
+              // Sum up durations and collect downtime segments for tooltips
+              let runSec = 0;
+              let downSec = 0;
+              const dayEvents = [];
+              for (const seg of merged) {
+                const duration = seg.end - seg.start;
+                if (seg.state === 1) {
+                  runSec += duration;
+                } else {
+                  downSec += duration;
+                  dayEvents.push({ start: seg.start, end: seg.end });
+                }
+              }
+              labels.push(new Date(dayStart * 1000).toISOString().slice(0, 10));
+              work.push(parseFloat((runSec / 3600).toFixed(1)));
+              down.push(parseFloat((downSec / 3600).toFixed(1)));
+              eventsByDay.push(dayEvents);
+            }
+            cb(null, { labels, work, down, events: eventsByDay });
+          }
+        );
+      }
+    );
+  }
+}
+
+module.exports = { Agent };


### PR DESCRIPTION
## Summary
- include stop/start events with timestamps in `/chartdata/:lineId`
- compute downtime events per day in the smoothing agent
- show downtime events via custom tooltip and provide 30-day report button

## Testing
- `node --check new_project/server.js`
- `node --check new_project/smartAgent.js`


------
https://chatgpt.com/codex/tasks/task_b_68a73de584488328ad7e0fb345568c6a