### PR TITLE
refactor: centralize credentials

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,14 +1,17 @@
-// Login credentials for the web application.  The username and password
+// Login credentials for the web application.  The username and passwords
 // are kept separate from runtime settings to avoid accidental changes when
-// editing the configuration from the settings page.  The password is
-// stored as a bcrypt hash and can be updated offline with a tool like
-// `bcryptjs` if needed.
+// editing the configuration from the settings page.  The main login password
+// is stored as a bcrypt hash and can be updated offline with a tool like
+// `bcryptjs` if needed.  The settings password is used to authorise changes
+// on the /settings page.
 
 module.exports = {
   // User name required to access the dashboard.  A separate password is
   // used for the settings page and must be provided there.
   username: "zavod",
-  // Bcrypt hash of the password.  The default password matches the
+  // Bcrypt hash of the login password.  The default password matches the
   // original build and may be updated by the operator.
-  passwordHash: "$2b$12$v6Afhzj5VUp7/k3yC469VeWcbfD2ro3y9R9v9bfniTvh1nsuucYOu"
+  passwordHash: "$2b$12$v6Afhzj5VUp7/k3yC469VeWcbfD2ro3y9R9v9bfniTvh1nsuucYOu",
+  // Plain settings password protecting the /settings interface.
+  settingsPassword: "19910509",
 };

--- a/config.json
+++ b/config.json
@@ -52,25 +52,15 @@
     "line8",
     "line9",
     "line10",
-    "line11",
-    "line12",
-    "line13"
-  ]
-  ,
-  // Login credentials for the dashboard.  The username and password
-  // protect access to the UI.  The password is stored in plain
-  // text here for simplicity; change it to a strong secret before
-  // deploying.
-  "loginUsername": "zavod",
-  "loginPassword": "H0lzH0f2025",
-  // Password required to access the settings page.  The same value
-  // appears in server code as a fallback.  You can change it here
-  // without touching the code.
-  "settingsPassword": "19910509",
-  // Product (номенклатура) assigned to each line.  Operators can
-  // change these values via the settings page.  The current product
-  // is stored with each state change event and included in reports.
-  "products": {
+  "line11",
+  "line12",
+  "line13"
+]
+,
+    // Product (номенклатура) assigned to each line.  Operators can
+    // change these values via the settings page.  The current product
+    // is stored with each state change event and included in reports.
+    "products": {
     "line1": "",
     "line2": "",
     "line3": "",

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
 const fs = require('fs');
 const ExcelJS = require('exceljs');
-const { username, passwordHash } = require('./config');
+const { username, passwordHash, settingsPassword } = require('./config');
 const { Agent } = require('./smartAgent');
 
 // -----------------------------------------------------------------------------
@@ -603,12 +603,9 @@ app.get('/settings', (req, res) => {
 app.post('/settings/auth', (req, res) => {
   try {
     const { password } = req.body || {};
-    // Hard‑coded password for accessing settings.  If needed, this
-    // could be externalised into the config.  The user must change
-    // this value in the specification if they want a different
-    // password for settings.
-    const settingsPassword = '19910509';
-    if (String(password) === settingsPassword) {
+    // Compare against the configured settings password.  The plain
+    // password lives in config.js alongside the login credentials.
+    if (String(password) === String(settingsPassword)) {
       req.session.settingsAuth = true;
       return res.json({ ok: true });
     }


### PR DESCRIPTION
## Summary
- centralize all credentials in `config.js`
- remove duplicate login fields from `config.json`
- load settings password from config instead of hardcoding

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_b_68a75cae63208328b69a4437811f0bc0