### PR TITLE
Fix authentication and enrich chart data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+source/new_project/data/
+source/new_project/__pycache__/

--- a/source/new_project/Dockerfile
+++ b/source/new_project/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy application files
+COPY . .
+
+# Install required Python packages for Excel reporting
+RUN pip install --no-cache-dir openpyxl
+
+# Expose the port used by the Python server
+EXPOSE 3000
+
+# Default command: run the Python server
+CMD ["python", "server.py"]

--- a/source/new_project/config.js
+++ b/source/new_project/config.js
@@ -1,0 +1,14 @@
+// Login credentials for the web application.  The username and password
+// are kept separate from runtime settings to avoid accidental changes when
+// editing the configuration from the settings page.  The password is
+// stored as a bcrypt hash and can be updated offline with a tool like
+// `bcryptjs` if needed.
+
+module.exports = {
+  // User name required to access the dashboard.  A separate password is
+  // used for the settings page and must be provided there.
+  username: "zavod",
+  // Bcrypt hash of the password.  The default password matches the
+  // original build and may be updated by the operator.
+  passwordHash: "$2b$12$v6Afhzj5VUp7/k3yC469VeWcbfD2ro3y9R9v9bfniTvh1nsuucYOu"
+};

--- a/source/new_project/config.json
+++ b/source/new_project/config.json
@@ -1,0 +1,93 @@
+{
+  // Number of seconds to use for smoothing the speed.  Incoming pulse
+  // packets are accumulated over this window and converted into a
+  // moving average speed (cm/min).
+  "windowSec": 60,
+  // Speed thresholds (cm/min) used to detect starts and stops.  When the
+  // smoothed speed rises above V_START for delayStart seconds the line
+  // transitions to RUN.  When the smoothed speed falls below V_STOP for
+  // delayStop seconds it transitions to STOP.
+  "V_START": 0.5,
+  "V_STOP": 0.3,
+  // Time (seconds) that the speed must remain above or below the
+  // threshold before a state change is logged.
+  "delayStart": 30,
+  "delayStop": 30,
+  // Depth of the speed chart in hours.  Supported values are 24 or 48.
+  "graphHours": 24,
+  // Maximum interval (seconds) between packets before the line is marked
+  // as stopped.  If no packets arrive for longer than this period the
+  // agent resets the smoothing buffer and forces the state to STOP.
+  "offlineTimeout": 60,
+  // Names of the lines shown in the UI.  Operators can customise these
+  // names via the settings page.  If a name is left empty the default
+  // identifier (line1, line2, ...) is used.
+  "lineNames": {
+    "line1": "Линия 1",
+    "line2": "Линия 2",
+    "line3": "Линия 3",
+    "line4": "Линия 4",
+    "line5": "Линия 5",
+    "line6": "Линия 6",
+    "line7": "Линия 7",
+    "line8": "Линия 8",
+    "line9": "Линия 9",
+    "line10": "Линия 10",
+    "line11": "Линия 11",
+    "line12": "Линия 12",
+    "line13": "Линия 13"
+  },
+  // By default all thirteen lines are enabled.  If a line is disabled
+  // (removed from this array) it will still appear in the UI but no
+  // smoothing or state detection will be performed until it receives
+  // packets.
+  "enabledLines": [
+    "line1",
+    "line2",
+    "line3",
+    "line4",
+    "line5",
+    "line6",
+    "line7",
+    "line8",
+    "line9",
+    "line10",
+    "line11",
+    "line12",
+    "line13"
+  ]
+  ,
+  // Login credentials for the dashboard.  The username and password
+  // protect access to the UI.  The password is stored in plain
+  // text here for simplicity; change it to a strong secret before
+  // deploying.
+  "loginUsername": "zavod",
+  "loginPassword": "H0lzH0f2025",
+  // Password required to access the settings page.  The same value
+  // appears in server code as a fallback.  You can change it here
+  // without touching the code.
+  "settingsPassword": "19910509",
+  // Product (номенклатура) assigned to each line.  Operators can
+  // change these values via the settings page.  The current product
+  // is stored with each state change event and included in reports.
+  "products": {
+    "line1": "",
+    "line2": "",
+    "line3": "",
+    "line4": "",
+    "line5": "",
+    "line6": "",
+    "line7": "",
+    "line8": "",
+    "line9": "",
+    "line10": "",
+    "line11": "",
+    "line12": "",
+    "line13": ""
+  },
+  // Telegram integration.  When both token and chatId are provided
+  // the agent will send messages to this chat when a line starts or
+  // stops.  Leave empty to disable notifications.
+  "telegramToken": "",
+  "telegramChatId": ""
+}

--- a/source/new_project/docker-compose.yml
+++ b/source/new_project/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  monitor:
+    build: .
+    container_name: extrusion_monitor
+    ports:
+      - "3000:3000"
+    volumes:
+      - data:/app/data
+    environment:
+      - TZ=Europe/Amsterdam
+    restart: unless-stopped
+
+volumes:
+  data:

--- a/source/new_project/package.json
+++ b/source/new_project/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "extrusion-monitor-clean",
+  "version": "1.0.0",
+  "description": "Clean build of extrusion monitor project with 13 automatic lines and smooth run/stop detection.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "express-session": "^1.17.3",
+    "sqlite3": "^5.1.2",
+    "bcrypt": "^5.1.0",
+    "exceljs": "^4.2.1"
+  }
+}

--- a/source/new_project/public/index.html
+++ b/source/new_project/public/index.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Монитор линий</title>
+  <!-- Tailwind for quick styling -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Chart.js for graphs -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="bg-gray-100 text-gray-900 min-h-screen">
+  <div id="app" class="p-4">
+    <div class="flex flex-col md:flex-row gap-4">
+      <!-- Left column: list of lines and settings button -->
+      <div class="w-full md:w-1/4">
+        <h2 class="text-lg font-bold mb-2">Линии</h2>
+        <div id="linesList" class="flex flex-col gap-2"></div>
+        <button id="settingsBtn" class="mt-4 px-3 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded">Настройки</button>
+      </div>
+      <!-- Right column: charts -->
+      <div class="flex-1">
+        <h2 id="lineTitle" class="text-lg font-bold mb-2">Скорость</h2>
+        <div class="bg-white p-4 rounded shadow">
+          <canvas id="speedChart"></canvas>
+        </div>
+        <h2 class="text-lg font-bold mt-6 mb-2">Работа / Простой (30 дней)</h2>
+        <div class="bg-white p-4 rounded shadow">
+          <canvas id="dailyChart"></canvas>
+        </div>
+        <button id="reportBtn" class="mt-4 px-3 py-2 bg-gray-500 hover:bg-gray-600 text-white rounded">Скачать отчёт за 30 дней</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    let currentLine = null;
+    let speedChart = null;
+    let dailyChart = null;
+    let dailyEvents = [];
+
+    // Create charts on first load
+    function createCharts() {
+      const ctx1 = document.getElementById('speedChart').getContext('2d');
+      speedChart = new Chart(ctx1, {
+        type: 'line',
+        data: {
+          labels: [],
+          datasets: [
+            {
+              label: 'Скорость (см/мин)',
+              data: [],
+              borderColor: '#2563eb',
+              backgroundColor: 'rgba(37, 99, 235, 0.2)',
+              pointRadius: 0,
+              fill: true,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: {
+            x: { display: true },
+            y: {
+              beginAtZero: true,
+              title: { display: true, text: 'см/мин' },
+            },
+          },
+          plugins: {
+            legend: { display: false },
+          },
+        },
+      });
+      const ctx2 = document.getElementById('dailyChart').getContext('2d');
+      dailyChart = new Chart(ctx2, {
+        type: 'bar',
+        data: {
+          labels: [],
+          datasets: [
+            {
+              label: 'Работа (ч)',
+              data: [],
+              backgroundColor: '#16a34a',
+            },
+            {
+              label: 'Простой (ч)',
+              data: [],
+              backgroundColor: '#dc2626',
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: {
+            x: { stacked: true },
+            y: {
+              stacked: true,
+              beginAtZero: true,
+              title: { display: true, text: 'Часы' },
+            },
+          },
+          plugins: {
+            tooltip: {
+              callbacks: {
+                afterBody: (items) => {
+                  const idx = items[0].dataIndex;
+                  const evs = dailyEvents[idx] || [];
+                  return evs.flatMap(ev => {
+                    const h = Math.floor(ev.durMin / 60);
+                    const m = ev.durMin % 60;
+                    if (ev.state === 1) {
+                      return [`Запуск: ${ev.startStr}`, `Работа: ${h} ч ${m} мин`];
+                    }
+                    return [`Остановка: ${ev.startStr}`, `Простой: ${h} ч ${m} мин`];
+                  });
+                }
+              }
+            }
+          }
+        },
+      });
+    }
+
+    // Load the current status for all lines and populate the list
+    async function loadStatus() {
+      try {
+        const res = await fetch('/status');
+        const lines = await res.json();
+        const container = document.getElementById('linesList');
+        container.innerHTML = '';
+        lines.forEach((item) => {
+          const div = document.createElement('div');
+          div.className = 'p-2 bg-white rounded shadow flex justify-between items-center cursor-pointer';
+          div.dataset.lineId = item.lineId;
+          const name = item.displayName || item.lineId;
+          const stateLabel = item.stateLabel;
+          const speed = (item.speed && !isNaN(item.speed)) ? item.speed.toFixed(1) : '-';
+          const product = item.product || '';
+          div.innerHTML = `
+            <div>
+              <div class="font-semibold">${name}</div>
+              <div class="text-sm text-gray-500">${stateLabel}</div>
+              <div class="text-xs text-gray-400">Изделие: ${product || '-'}</div>
+            </div>
+            <div class="text-right">
+              <div class="font-mono">${speed}</div>
+            </div>
+          `;
+          div.addEventListener('click', () => {
+            selectLine(item.lineId);
+          });
+          if (currentLine === null) {
+            currentLine = item.lineId;
+          }
+          container.appendChild(div);
+        });
+        // Highlight the selected line
+        Array.from(container.children).forEach((child) => {
+          child.classList.remove('border', 'border-blue-500');
+          if (child.dataset.lineId === currentLine) {
+            child.classList.add('border', 'border-blue-500');
+          }
+        });
+      } catch (e) {
+        console.error('loadStatus', e);
+      }
+    }
+
+    // Change the selected line and refresh charts
+    async function selectLine(lineId) {
+      currentLine = lineId;
+      await updateCharts();
+      // update highlight
+      const container = document.getElementById('linesList');
+      Array.from(container.children).forEach((child) => {
+        child.classList.remove('border', 'border-blue-500');
+        if (child.dataset.lineId === lineId) {
+          child.classList.add('border', 'border-blue-500');
+        }
+      });
+    }
+
+    // Fetch chart data for the current line and update both charts
+    async function updateCharts() {
+      if (!currentLine) return;
+      try {
+        const res = await fetch('/chartdata/' + currentLine);
+        const data = await res.json();
+        // Speed chart
+        speedChart.data.labels = data.speed.labels;
+        speedChart.data.datasets[0].data = data.speed.data;
+        speedChart.update();
+        // Daily chart
+        dailyEvents = data.status.events || [];
+        dailyChart.data.labels = data.status.labels;
+        dailyChart.data.datasets[0].data = data.status.work;
+        dailyChart.data.datasets[1].data = data.status.down;
+        dailyChart.update();
+        document.getElementById('lineTitle').textContent = `${data.status.lineName || currentLine} — скорость`;
+      } catch (e) {
+        console.error('updateCharts', e);
+      }
+    }
+
+    // Periodically refresh status and charts
+    async function periodic() {
+      await loadStatus();
+      await updateCharts();
+      setTimeout(periodic, 15000);
+    }
+
+    window.addEventListener('DOMContentLoaded', () => {
+      createCharts();
+      loadStatus().then(() => {
+        selectLine(currentLine);
+      });
+      periodic();
+      document.getElementById('settingsBtn').addEventListener('click', () => {
+        window.location.href = '/settings';
+      });
+      document.getElementById('reportBtn').addEventListener('click', () => {
+        window.location.href = '/report';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/source/new_project/public/login.html
+++ b/source/new_project/public/login.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Вход</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen flex items-center justify-center">
+  <div class="bg-white p-6 rounded shadow w-80">
+    <h1 class="text-xl font-bold mb-4 text-center">Вход</h1>
+    <form method="post" action="/login" class="space-y-4">
+      <input type="text" name="username" placeholder="Логин" class="w-full border p-2 rounded" required />
+      <input type="password" name="password" placeholder="Пароль" class="w-full border p-2 rounded" required />
+      <label class="flex items-center"><input type="checkbox" name="remember" class="mr-2" />Запомнить меня</label>
+      <button type="submit" class="w-full bg-blue-500 hover:bg-blue-600 text-white py-2 rounded">Войти</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/source/new_project/public/settings.html
+++ b/source/new_project/public/settings.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Настройки</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 text-gray-900 min-h-screen p-4">
+  <h1 class="text-2xl font-bold mb-4">Настройки</h1>
+  <!-- Authentication form -->
+  <div id="authForm" class="space-y-4">
+    <p>Введите пароль для доступа к настройкам:</p>
+    <input type="password" id="authPass" class="border p-2 rounded w-64" placeholder="Пароль" />
+    <button id="authSubmit" class="px-3 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded">Войти</button>
+    <p id="authError" class="text-red-600 hidden">Неверный пароль</p>
+  </div>
+  <!-- Settings form -->
+  <div id="settingsForm" class="space-y-4 hidden">
+    <label class="block">Окно усреднения (сек):
+      <input id="windowSec" type="number" min="1" class="border p-2 rounded ml-2 w-32" />
+      <span class="text-xs text-gray-500 block">Время (сек), за которое усредняется скорость. Чем больше значение, тем плавнее график.</span>
+    </label>
+    <label class="block">Порог запуска V_START (см/мин):
+      <input id="V_START" type="number" step="0.1" class="border p-2 rounded ml-2 w-32" />
+      <span class="text-xs text-gray-500 block">Если усреднённая скорость превышает этот порог в течение delayStart, линия считается запущенной.</span>
+    </label>
+    <label class="block">Порог остановки V_STOP (см/мин):
+      <input id="V_STOP" type="number" step="0.1" class="border p-2 rounded ml-2 w-32" />
+      <span class="text-xs text-gray-500 block">Если усреднённая скорость падает ниже этого порога в течение delayStop, линия считается остановленной.</span>
+    </label>
+    <label class="block">Задержка запуска (сек):
+      <input id="delayStart" type="number" min="0" class="border p-2 rounded ml-2 w-32" />
+      <span class="text-xs text-gray-500 block">Минимальное время, в течение которого скорость должна быть выше V_START, чтобы зафиксировать запуск.</span>
+    </label>
+    <label class="block">Задержка остановки (сек):
+      <input id="delayStop" type="number" min="0" class="border p-2 rounded ml-2 w-32" />
+      <span class="text-xs text-gray-500 block">Минимальное время, в течение которого скорость должна быть ниже V_STOP, чтобы зафиксировать остановку.</span>
+    </label>
+    <label class="block">Глубина графика (часы):
+      <select id="graphHours" class="border p-2 rounded ml-2 w-32">
+        <option value="24">24</option>
+        <option value="48">48</option>
+      </select>
+      <span class="text-xs text-gray-500 block">Период, отображаемый на графике скорости.</span>
+    </label>
+    <label class="block">Тайм‑аут ожидания пакета (сек):
+      <input id="offlineTimeout" type="number" min="1" class="border p-2 rounded ml-2 w-32" />
+      <span class="text-xs text-gray-500 block">Если пакеты не приходят дольше этого времени, линия считается остановленной.</span>
+    </label>
+    <label class="block">Telegram Token:
+      <input id="telegramToken" type="text" class="border p-2 rounded ml-2 w-64" />
+      <span class="text-xs text-gray-500 block">Токен бота для отправки уведомлений (оставьте пустым, чтобы отключить).</span>
+    </label>
+    <label class="block">Telegram Chat ID:
+      <input id="telegramChatId" type="text" class="border p-2 rounded ml-2 w-64" />
+      <span class="text-xs text-gray-500 block">ID чата, куда отправлять уведомления.</span>
+    </label>
+    <div>
+      <h2 class="font-semibold mt-4 mb-2">Линии</h2>
+      <div id="linesConfig" class="space-y-2"></div>
+    </div>
+    <button id="saveBtn" class="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded">Сохранить</button>
+    <p id="saveMsg" class="text-green-600 hidden">Настройки сохранены</p>
+  </div>
+  <script>
+    async function checkAuth() {
+      try {
+        const res = await fetch('/settings/info');
+        if (res.status === 200) {
+          const data = await res.json();
+          document.getElementById('authForm').classList.add('hidden');
+          document.getElementById('settingsForm').classList.remove('hidden');
+          loadSettings(data);
+        } else if (res.status === 401) {
+          document.getElementById('authForm').classList.remove('hidden');
+          document.getElementById('settingsForm').classList.add('hidden');
+        }
+      } catch (e) {
+        console.error('checkAuth', e);
+      }
+    }
+    function loadSettings(data) {
+      document.getElementById('windowSec').value = data.windowSec;
+      document.getElementById('V_START').value = data.V_START;
+      document.getElementById('V_STOP').value = data.V_STOP;
+      document.getElementById('delayStart').value = data.delayStart;
+      document.getElementById('delayStop').value = data.delayStop;
+      document.getElementById('graphHours').value = data.graphHours;
+      document.getElementById('offlineTimeout').value = data.offlineTimeout || 60;
+      document.getElementById('telegramToken').value = data.telegramToken || '';
+      document.getElementById('telegramChatId').value = data.telegramChatId || '';
+      // Build lines configuration
+      const linesDiv = document.getElementById('linesConfig');
+      linesDiv.innerHTML = '';
+      const enabled = data.enabledLines || [];
+      const names = data.lineNames || {};
+      const products = data.products || {};
+      for (let i = 1; i <= 13; i++) {
+        const id = 'line' + i;
+        const row = document.createElement('div');
+        row.className = 'flex flex-wrap items-center gap-2';
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.id = 'en_' + id;
+        checkbox.checked = enabled.includes(id);
+        const label = document.createElement('label');
+        label.htmlFor = 'en_' + id;
+        label.textContent = id;
+        const nameInput = document.createElement('input');
+        nameInput.type = 'text';
+        nameInput.id = 'name_' + id;
+        nameInput.value = names[id] || '';
+        nameInput.placeholder = id;
+        nameInput.className = 'border p-1 rounded flex-1';
+        const prodInput = document.createElement('input');
+        prodInput.type = 'text';
+        prodInput.id = 'prod_' + id;
+        prodInput.value = products[id] || '';
+        prodInput.placeholder = 'Изделие';
+        prodInput.className = 'border p-1 rounded flex-1';
+        row.appendChild(checkbox);
+        row.appendChild(label);
+        row.appendChild(nameInput);
+        row.appendChild(prodInput);
+        linesDiv.appendChild(row);
+      }
+    }
+    async function authenticate() {
+      const pass = document.getElementById('authPass').value;
+      try {
+        const res = await fetch('/settings/auth', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ password: pass }),
+        });
+        if (res.status === 200) {
+          document.getElementById('authError').classList.add('hidden');
+          checkAuth();
+        } else {
+          document.getElementById('authError').classList.remove('hidden');
+        }
+      } catch (e) {
+        console.error('authenticate', e);
+      }
+    }
+    async function saveSettings() {
+      const cfg = {};
+      cfg.windowSec = Number(document.getElementById('windowSec').value) || 60;
+      cfg.V_START = Number(document.getElementById('V_START').value) || 0.5;
+      cfg.V_STOP = Number(document.getElementById('V_STOP').value) || 0.3;
+      cfg.delayStart = Number(document.getElementById('delayStart').value) || 30;
+      cfg.delayStop = Number(document.getElementById('delayStop').value) || 30;
+      cfg.graphHours = Number(document.getElementById('graphHours').value) || 24;
+      cfg.offlineTimeout = Number(document.getElementById('offlineTimeout').value) || 60;
+      cfg.enabledLines = [];
+      cfg.lineNames = {};
+      for (let i = 1; i <= 13; i++) {
+        const id = 'line' + i;
+        const enabled = document.getElementById('en_' + id).checked;
+        if (enabled) cfg.enabledLines.push(id);
+        const nameVal = document.getElementById('name_' + id).value.trim();
+        cfg.lineNames[id] = nameVal;
+      }
+      // collect product assignments
+      cfg.products = {};
+      for (let i = 1; i <= 13; i++) {
+        const id = 'line' + i;
+        const prodVal = document.getElementById('prod_' + id).value.trim();
+        cfg.products[id] = prodVal;
+      }
+      // Telegram credentials
+      cfg.telegramToken = document.getElementById('telegramToken').value.trim();
+      cfg.telegramChatId = document.getElementById('telegramChatId').value.trim();
+      try {
+        const res = await fetch('/settings/save', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(cfg),
+        });
+        if (res.status === 200) {
+          document.getElementById('saveMsg').classList.remove('hidden');
+          setTimeout(() => {
+            document.getElementById('saveMsg').classList.add('hidden');
+          }, 3000);
+        }
+      } catch (e) {
+        console.error('saveSettings', e);
+      }
+    }
+    document.getElementById('authSubmit').addEventListener('click', authenticate);
+    document.getElementById('saveBtn').addEventListener('click', saveSettings);
+    checkAuth();
+  </script>
+</body>
+</html>

--- a/source/new_project/server.js
+++ b/source/new_project/server.js
@@ -1,0 +1,763 @@
+/*
+ * server.js
+ *
+ * Main entry point for the clean extrusion monitor.  This file
+ * implements a simple REST API for ingesting pulse data, retrieving
+ * smoothed speeds and uptime statistics, generating Excel reports and
+ * configuring the smoothing parameters.  The application exposes a
+ * minimal user interface in the `public/` directory and protects
+ * access behind a login page.  A separate password is required to
+ * access the settings page.
+ */
+
+process.env.TZ = 'Etc/GMT-4';
+const express = require('express');
+const session = require('express-session');
+const bcrypt = require('bcrypt');
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+const fs = require('fs');
+const ExcelJS = require('exceljs');
+const { username, passwordHash } = require('./config');
+const { Agent } = require('./smartAgent');
+
+const pad = (n) => String(n).padStart(2, '0');
+function formatDateTime(ts) {
+  const d = new Date(ts * 1000);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+function formatDate(ts) {
+  const d = new Date(ts * 1000);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+function formatTime(ts) {
+  const d = new Date(ts * 1000);
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+// -----------------------------------------------------------------------------
+// Configuration loading/saving
+//
+// Runtime settings (smoothing parameters, line names, etc.) are stored in
+// JSON format in config.json.  The settings may be modified at runtime
+// through the /settings API.  These helper functions load and persist
+// the settings atomically.  If the file does not exist, sensible
+// defaults are returned based on the committed version of config.json.
+
+const SETTINGS_PATH = path.join(__dirname, 'config.json');
+
+/**
+ * Load settings from disk.  If the settings file does not exist the
+ * committed defaults are returned.
+ *
+ * @returns {Object} Parsed settings.
+ */
+function loadSettings() {
+  try {
+    const raw = fs.readFileSync(SETTINGS_PATH, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    // Fall back to the committed defaults.  Using require ensures the
+    // default file is read relative to this module and cached for the
+    // lifetime of the process.
+    // eslint-disable-next-line import/no-dynamic-require
+    const defaults = require('./config.json');
+    return Object.assign({}, defaults);
+  }
+}
+
+/**
+ * Persist settings to disk.  The file is overwritten atomically to
+ * avoid corruption.
+ *
+ * @param {Object} obj Settings to save.
+ */
+function saveSettings(obj) {
+  fs.writeFileSync(SETTINGS_PATH, JSON.stringify(obj, null, 2));
+}
+
+// Load the initial settings into memory.  These values will be
+// propagated into the smoothing agent and subsequently updated via the
+// /settings API.
+let settings = loadSettings();
+
+// -----------------------------------------------------------------------------
+// Database setup
+//
+// All runtime state (status flags, event logs and minute aggregates) are
+// persisted in an SQLite database in the `data/` directory.  The
+// directory is created on startup if it does not exist.  Basic tables
+// are initialised here; more specialised tables (minute_stats) are
+// created by the smartAgent.
+
+const DATA_DIR = path.join(__dirname, 'data');
+if (!fs.existsSync(DATA_DIR)) {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+}
+const db = new sqlite3.Database(path.join(DATA_DIR, 'data.db'));
+
+// Create the core tables.  `status` tracks the current RUN/STOP
+// information per line and the time of the last packet; `status_log`
+// records state changes; `pulses` stores raw packet data for
+// completeness (currently unused by the front‑end).
+db.serialize(() => {
+  db.run(
+    `CREATE TABLE IF NOT EXISTS status (
+      lineId TEXT PRIMARY KEY,
+      isRunning INTEGER DEFAULT 0,
+      lastPulseTime INTEGER DEFAULT 0,
+      lastPacketTime INTEGER DEFAULT 0
+    )`
+  );
+  db.run(
+    `CREATE TABLE IF NOT EXISTS status_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      lineId TEXT,
+      timestamp INTEGER,
+      isRunning INTEGER
+    )`
+  );
+  db.run(
+    `CREATE TABLE IF NOT EXISTS pulses (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      lineId TEXT,
+      pulses INTEGER,
+      duration INTEGER,
+      timestamp INTEGER
+    )`
+  );
+  // Seed the 13 lines if they do not already exist.  Each line will
+  // persist even if disabled in the settings to ensure the UI shows
+  // inactive lines as "нет данных".
+  const lines = Array.from({ length: 13 }, (_, i) => `line${i + 1}`);
+  lines.forEach((lineId) => {
+    db.get(
+      `SELECT lineId FROM status WHERE lineId=?`,
+      [lineId],
+      (err, row) => {
+        if (err) return;
+        if (!row) {
+          db.run(
+            `INSERT INTO status(lineId,isRunning,lastPulseTime,lastPacketTime) VALUES (?,?,?,?)`,
+            [lineId, 0, 0, 0]
+          );
+        }
+      }
+    );
+  });
+});
+
+// Instantiate the smoothing agent.  The agent maintains its own
+// in‑memory buffers and writes minute aggregates to the database via
+// minute_stats.  Whenever the settings are updated the agent will be
+// notified by calling `updateSettings()`.
+const agent = new Agent(db, settings);
+
+// -----------------------------------------------------------------------------
+// Express application
+//
+// The API and UI are served by a single Express instance.  Sessions are
+// used to protect access to the dashboard and settings; login is
+// required for all routes except a handful of public endpoints.
+
+const app = express();
+app.use(express.json({ limit: '64kb' }));
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || 'extrusion-monitor-secret',
+    resave: false,
+    saveUninitialized: false,
+  })
+);
+
+/**
+ * Middleware to enforce authentication for protected routes.  Requests
+ * to the login page, static assets, the data ingestion endpoint and
+ * health endpoints are permitted without a session.
+ */
+function requireAuth(req, res, next) {
+  const openPaths = ['/login', '/public', '/data', '/healthz', '/time'];
+  if (openPaths.some((p) => req.path === p || req.path.startsWith(p + '/'))) {
+    return next();
+  }
+  if (req.session && req.session.user === username) {
+    return next();
+  }
+  return res.redirect('/login');
+}
+
+// -----------------------------------------------------------------------------
+// Authentication routes
+
+app.get('/login', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'login.html'));
+});
+
+app.post(
+  '/login',
+  express.urlencoded({ extended: true }),
+  async (req, res) => {
+    try {
+      const { username: u, password, remember } = req.body || {};
+      if (u === username && (await bcrypt.compare(String(password || ''), passwordHash))) {
+        req.session.user = username;
+        if (remember) {
+          req.session.cookie.maxAge = 30 * 86400 * 1000; // 30 days
+        }
+        return res.redirect('/');
+      }
+    } catch (e) {
+      console.error('login error', e);
+    }
+    res.status(401).send('Unauthorized');
+  }
+);
+
+app.get('/logout', (req, res) => {
+  req.session.destroy(() => {
+    res.redirect('/login');
+  });
+});
+
+// Apply authentication middleware
+app.use(requireAuth);
+
+// -----------------------------------------------------------------------------
+// Static files
+
+// Serve all files under public/ at /public/ so that CSS and JS
+// dependencies can be loaded directly.
+app.use('/public', express.static(path.join(__dirname, 'public')));
+
+// The root of the application serves the dashboard.  Since
+// requireAuth runs before this route, users will be redirected to
+// /login if they are not authenticated.
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+// -----------------------------------------------------------------------------
+// Data ingestion
+
+// POST /data accepts packets from the ESP32 containing pulses, the
+// duration of the sampling interval and an optional timestamp.
+// Example packet: { "lineId": "line1", "pulses": 42, "duration": 10000, "ts": 1692922200 }
+// If no timestamp is provided the current server time is used.  The
+// server stores the raw packet, updates its smoothing buffers and
+// records any RUN/STOP transitions to the event log.
+app.post('/data', (req, res) => {
+  try {
+    const { lineId, pulses, duration, ts } = req.body || {};
+    const id = String(lineId || '').trim();
+    const p = Number(pulses);
+    const dur = Number(duration);
+    if (!id || !Number.isFinite(p) || !Number.isFinite(dur) || dur <= 0) {
+      return res.status(400).json({ error: 'invalid payload' });
+    }
+    // Normalise timestamp inside the agent.  We insert the raw packet
+    // into pulses purely for archival purposes; the ingestion logic
+    // itself does not read from this table.
+    const pktTs = ts;
+    db.run(
+      `INSERT INTO pulses(lineId,pulses,duration,timestamp) VALUES (?,?,?,?)`,
+      [id, p, dur, Math.floor((ts && ts > 1e12 ? ts / 1000 : ts) || Date.now() / 1000)],
+      () => {}
+    );
+    // Ensure the line exists in the status table.  If it is a new
+    // identifier it will be inserted with default values.
+    db.get(
+      `SELECT lineId,isRunning FROM status WHERE lineId=?`,
+      [id],
+      (err, row) => {
+        if (err) {
+          console.error('status fetch', err);
+          return res.status(500).json({ error: 'db' });
+        }
+        if (!row) {
+          db.run(
+            `INSERT INTO status(lineId,isRunning,lastPulseTime,lastPacketTime) VALUES (?,?,?,?)`,
+            [id, 0, 0, 0],
+            () => {}
+          );
+        }
+        // Feed the packet into the smoothing agent.  The agent
+        // determines whether a state change occurred and returns
+        // smoothed speed.
+        const { smoothedSpeed, stateChanged, newState } = agent.ingest(id, {
+          pulses: p,
+          duration: dur,
+          ts: pktTs,
+        });
+        const nowSec = Math.floor(Date.now() / 1000);
+        // Update the status table's timing fields.  lastPacketTime is
+        // always updated; lastPulseTime is updated only when pulses>0.
+        const updates = [];
+        const params = [];
+        updates.push('lastPacketTime=?');
+        params.push(nowSec);
+        if (p > 0) {
+          updates.push('lastPulseTime=?');
+          params.push(nowSec);
+        }
+        if (stateChanged) {
+          updates.push('isRunning=?');
+          params.push(newState);
+        }
+        params.push(id);
+        db.run(
+          `UPDATE status SET ${updates.join(', ')} WHERE lineId=?`,
+          params,
+          () => {
+            if (stateChanged) {
+              db.run(
+                `INSERT INTO status_log(lineId,timestamp,isRunning) VALUES (?,?,?)`,
+                [id, nowSec, newState],
+                () => {}
+              );
+            }
+            res.json({ ok: true });
+          }
+        );
+      }
+    );
+  } catch (e) {
+    console.error('/data error', e);
+    res.status(500).json({ error: 'server' });
+  }
+});
+
+// -----------------------------------------------------------------------------
+// Status endpoint
+
+// GET /status returns the current state of all 13 lines.  Each entry
+// contains the lineId, a human‑friendly displayName, the smoothed
+// speed and a label describing whether the line is running, stopped
+// or has no data.  Lines that have never received a packet are
+// reported as having no data.
+app.get('/status', (req, res) => {
+  const lines = Array.from({ length: 13 }, (_, i) => `line${i + 1}`);
+  db.all(`SELECT lineId,isRunning,lastPulseTime,lastPacketTime FROM status ORDER BY lineId ASC`, (err, rows) => {
+    if (err) {
+      console.error('/status db', err);
+      return res.json([]);
+    }
+    const nowSec = Math.floor(Date.now() / 1000);
+    const result = [];
+    for (const id of lines) {
+      const row = rows.find((r) => r.lineId === id) || { lineId: id, isRunning: 0, lastPulseTime: 0, lastPacketTime: 0 };
+      const smoothedSpeed = agent.getSmoothedSpeed(id);
+      const isRunning = agent.getState(id);
+      // Determine whether the line is offline.  If no packet has ever
+      // been received (lastPacketTime=0) or the elapsed time since the
+      // last packet exceeds offlineTimeout we label it as having no
+      // data.  Otherwise we reflect its running/stopped state.
+      let stateLabel = 'нет данных';
+      if (row.lastPacketTime && nowSec - row.lastPacketTime <= (settings.offlineTimeout || 60)) {
+        stateLabel = isRunning ? 'Работает' : 'Остановлена';
+      }
+      const displayName = (settings.lineNames && settings.lineNames[id]) || id;
+      const product = (settings.products && settings.products[id]) || '';
+      result.push({
+        lineId: id,
+        displayName,
+        product,
+        speed: smoothedSpeed,
+        isRunning: !!isRunning,
+        lastPulseTime: row.lastPulseTime,
+        lastPacketTime: row.lastPacketTime,
+        stateLabel,
+      });
+    }
+    res.json(result);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Chart data endpoint
+
+// GET /chartdata/:lineId returns the time series for the selected line
+// along with the last 30 days of uptime/downtime statistics.  The
+// number of hours in the speed chart is determined by the current
+// settings (graphHours) and the daily aggregation uses 30 days.
+app.get('/chartdata/:lineId', (req, res) => {
+  const lineId = String(req.params.lineId || '').trim();
+  const hours = Number(settings.graphHours) || 24;
+  agent.getSeries(lineId, hours, (err1, series) => {
+    if (err1 || !series) {
+      console.error('getSeries', err1);
+      return res.status(500).json({ error: 'series' });
+    }
+    agent.getDailyWorkIdle(lineId, 30, (err2, daily) => {
+      if (err2 || !daily) {
+        console.error('getDailyWorkIdle', err2);
+        return res.status(500).json({ error: 'daily' });
+      }
+      const lineName = (settings.lineNames && settings.lineNames[lineId]) || lineId;
+      const speed = {
+        labels: series.labels,
+        data: series.data,
+      };
+      const status = {
+        labels: daily.labels,
+        work: daily.work,
+        down: daily.down,
+        events: daily.events,
+        lineName,
+      };
+      res.json({ speed, status });
+    });
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Excel reports
+
+// GET /report generates a detailed Excel report including per‑event
+// breakdowns of running and stopped segments as well as a summary
+// sheet.  The implementation mirrors the old system but uses the
+// merged segments logic to ignore short stops and runs.  The report
+// spans the last 30 days by default or can be constrained via
+// ?from=YYYY-MM-DD&to=YYYY-MM-DD.  Dates are interpreted in the
+// server's local timezone.
+app.get('/report', async (req, res) => {
+  try {
+    // Parse optional from/to parameters.  If omitted the last 30 days
+    // are included.  Convert ISO dates to UNIX timestamps.
+    const parseDate = (s) => {
+      if (!s) return null;
+      const d = new Date(s);
+      if (isNaN(d.getTime())) return null;
+      return Math.floor(d.getTime() / 1000);
+    };
+    const nowSec = Math.floor(Date.now() / 1000);
+    const toTs = parseDate(req.query.to) || nowSec;
+    const fromTs = parseDate(req.query.from) || toTs - 30 * 86400;
+    const wb = new ExcelJS.Workbook();
+    const summary = wb.addWorksheet('Сводка 30 дней');
+    summary.columns = [
+      { header: 'Линия', key: 'line', width: 12 },
+      { header: 'Работа, ч', key: 'up', width: 14 },
+      { header: 'Простой, ч', key: 'down', width: 14 },
+      { header: '% простоя', key: 'pct', width: 12 },
+    ];
+    const lines = Array.from({ length: 13 }, (_, i) => `line${i + 1}`);
+    for (const lineId of lines) {
+      // Build a per‑line worksheet
+      const ws = wb.addWorksheet(lineId);
+      ws.columns = [
+        { header: 'Дата', key: 'date', width: 12 },
+        { header: 'Событие', key: 'ev', width: 18 },
+        { header: 'Время', key: 'when', width: 20 },
+        { header: 'Простой, мин', key: 'downtime', width: 14 },
+        { header: 'Изделие', key: 'product', width: 20 },
+      ];
+      const product = (settings.products && settings.products[lineId]) || '';
+      // Helper to add a row to the worksheet
+      function addRow(date, ev, whenTs, extra) {
+        const whenStr = formatDateTime(whenTs);
+        ws.addRow({ date, ev, when: whenStr, downtime: extra, product });
+      }
+      // Determine the state at fromTs
+      const initial = await new Promise((resolve) => {
+        db.get(
+          `SELECT isRunning FROM status_log WHERE lineId=? AND timestamp<? ORDER BY timestamp DESC LIMIT 1`,
+          [lineId, fromTs],
+          (err, row) => {
+            resolve(row ? Number(row.isRunning) : 0);
+          }
+        );
+      });
+      // Fetch all logs within the requested range
+      const logs = await new Promise((resolve) => {
+        db.all(
+          `SELECT timestamp,isRunning FROM status_log WHERE lineId=? AND timestamp>=? AND timestamp<=? ORDER BY timestamp ASC`,
+          [lineId, fromTs, toTs],
+          (err, rows) => {
+            resolve(rows || []);
+          }
+        );
+      });
+      // Iterate through each day between fromTs and toTs and build
+      // segments.  We'll accumulate total run/down time for the summary.
+      let totalRun = 0;
+      let totalDown = 0;
+      let prevState = initial;
+      for (let dayStart = Math.floor(fromTs / 86400) * 86400; dayStart < toTs; dayStart += 86400) {
+        const dayEnd = Math.min(dayStart + 86400, toTs);
+        const dayLabel = formatDate(dayStart);
+        // Build raw segments for this day
+        const dayEvents = logs.filter((ev) => ev.timestamp >= dayStart && ev.timestamp < dayEnd);
+        let state = prevState;
+        let segStart = dayStart;
+        const segments = [];
+        for (const ev of dayEvents) {
+          if (Number(ev.isRunning) !== state) {
+            segments.push({ start: segStart, end: ev.timestamp, state });
+            state = Number(ev.isRunning);
+            segStart = ev.timestamp;
+          }
+        }
+        segments.push({ start: segStart, end: dayEnd, state });
+        prevState = state;
+        // Merge short segments (<60s) into the opposite state
+        const merged = [];
+        for (const seg of segments) {
+          const dur = seg.end - seg.start;
+          if (seg.state === 1 && dur < 60) {
+            // short run => downtime
+            if (merged.length && merged[merged.length - 1].state === 0) {
+              merged[merged.length - 1].end = seg.end;
+            } else {
+              merged.push({ start: seg.start, end: seg.end, state: 0 });
+            }
+          } else if (seg.state === 0 && dur < 60) {
+            // short stop => uptime
+            if (merged.length && merged[merged.length - 1].state === 1) {
+              merged[merged.length - 1].end = seg.end;
+            } else {
+              merged.push({ start: seg.start, end: seg.end, state: 1 });
+            }
+          } else {
+            merged.push({ ...seg });
+          }
+        }
+        // Write merged segments to worksheet
+        for (let i = 0; i < merged.length; i++) {
+          const seg = merged[i];
+          const durMin = Math.round((seg.end - seg.start) / 60);
+          if (seg.state === 1) {
+            totalRun += seg.end - seg.start;
+            addRow(dayLabel, 'Работа', seg.start, String(durMin));
+            addRow(dayLabel, 'Остановка', seg.end, '');
+          } else {
+            totalDown += seg.end - seg.start;
+            addRow(dayLabel, 'Простой', seg.start, String(durMin));
+            if (i < merged.length - 1 && merged[i + 1].state === 1) {
+              addRow(dayLabel, 'Запуск', seg.end, '');
+            }
+          }
+        }
+      }
+      // Add a summary row for this line
+      const total = totalRun + totalDown;
+      const pct = total ? ((totalDown / total) * 100).toFixed(1) + '%' : '0.0%';
+      summary.addRow({ line: lineId, up: (totalRun / 3600).toFixed(1), down: (totalDown / 3600).toFixed(1), pct });
+    }
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', 'attachment; filename="report.xlsx"');
+    await wb.xlsx.write(res);
+    res.end();
+  } catch (e) {
+    console.error('/report error', e);
+    res.status(500).json({ error: 'report' });
+  }
+});
+
+// GET /report_clean generates a simplified 30‑day summary report using
+// the smoothing agent to compute uptime and downtime.  Each line
+// receives its own sheet and a summary is provided on the first page.
+app.get('/report_clean', async (req, res) => {
+  try {
+    const wb = new ExcelJS.Workbook();
+    const summary = wb.addWorksheet('Сводка 30 дней');
+    summary.columns = [
+      { header: 'Линия', key: 'line', width: 12 },
+      { header: 'Работа, ч', key: 'up', width: 14 },
+      { header: 'Простой, ч', key: 'down', width: 14 },
+      { header: '% простоя', key: 'pct', width: 12 },
+    ];
+    const lines = Array.from({ length: 13 }, (_, i) => `line${i + 1}`);
+    for (const lineId of lines) {
+      const sheet = wb.addWorksheet(lineId);
+      sheet.columns = [
+        { header: 'Дата', key: 'date', width: 12 },
+        { header: 'Работа, ч', key: 'up', width: 14 },
+        { header: 'Простой, ч', key: 'down', width: 14 },
+      ];
+      await new Promise((resolve) => {
+        agent.getDailyWorkIdle(lineId, 30, (err, daily) => {
+          if (!err && daily) {
+            let runTotal = 0;
+            let downTotal = 0;
+            for (let i = 0; i < daily.labels.length; i++) {
+              const date = daily.labels[i];
+              const up = daily.work[i];
+              const down = daily.down[i];
+              runTotal += up;
+              downTotal += down;
+              sheet.addRow({ date, up, down });
+            }
+            const total = runTotal + downTotal;
+            const pct = total ? ((downTotal / total) * 100).toFixed(1) + '%' : '0.0%';
+            summary.addRow({ line: lineId, up: runTotal.toFixed(1), down: downTotal.toFixed(1), pct });
+          }
+          resolve();
+        });
+      });
+    }
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', 'attachment; filename="report_30days_clean.xlsx"');
+    await wb.xlsx.write(res);
+    res.end();
+  } catch (e) {
+    console.error('/report_clean error', e);
+    res.status(500).json({ error: 'report_clean' });
+  }
+});
+
+// Convenience route used by the old UI; forwards to the simplified
+// report.  Clients can call /report/last30days directly to obtain
+// report_30days_clean.xlsx.
+app.get('/report/last30days', (req, res) => {
+  req.url = '/report_clean';
+  app._router.handle(req, res, () => {});
+});
+
+// -----------------------------------------------------------------------------
+// Settings API
+
+// GET /settings serves the settings page.  Authentication via requireAuth
+// ensures only logged in users can access it.  Authorisation for
+// editing settings is enforced in the AJAX endpoints.
+app.get('/settings', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'settings.html'));
+});
+
+// POST /settings/auth verifies the settings password.  If successful
+// the session gains a `settingsAuth` flag which is required to call
+// /settings/info and /settings/save.
+app.post('/settings/auth', (req, res) => {
+  try {
+    const { password } = req.body || {};
+    // Hard‑coded password for accessing settings.  If needed, this
+    // could be externalised into the config.  The user must change
+    // this value in the specification if they want a different
+    // password for settings.
+    const settingsPassword = '19910509';
+    if (String(password) === settingsPassword) {
+      req.session.settingsAuth = true;
+      return res.json({ ok: true });
+    }
+    return res.status(401).json({ error: 'wrong password' });
+  } catch (e) {
+    console.error('/settings/auth', e);
+    res.status(500).json({ error: 'server' });
+  }
+});
+
+// GET /settings/info returns the current settings to authenticated
+// settings users.  Without settingsAuth this endpoint returns 401.
+app.get('/settings/info', (req, res) => {
+  if (!req.session.settingsAuth) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  res.json(settings);
+});
+
+// POST /settings/save persists new settings.  The payload replaces
+// existing values; missing fields retain their previous values.  After
+// saving to disk the in‑memory settings and the agent are updated.
+app.post('/settings/save', (req, res) => {
+  if (!req.session.settingsAuth) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  try {
+    const body = req.body || {};
+    // Validate and coerce incoming values.  Fallback to existing
+    // settings when values are missing or invalid.
+    const newCfg = Object.assign({}, settings);
+    const num = (v, def) => {
+      const n = Number(v);
+      return Number.isFinite(n) && n >= 0 ? n : def;
+    };
+    newCfg.windowSec = num(body.windowSec, settings.windowSec);
+    newCfg.V_START = num(body.V_START, settings.V_START);
+    newCfg.V_STOP = num(body.V_STOP, settings.V_STOP);
+    newCfg.delayStart = num(body.delayStart, settings.delayStart);
+    newCfg.delayStop = num(body.delayStop, settings.delayStop);
+    newCfg.graphHours = num(body.graphHours, settings.graphHours);
+    newCfg.offlineTimeout = num(body.offlineTimeout, settings.offlineTimeout);
+    // Enabled lines should be an array of strings; if omitted use
+    // existing enabledLines.
+    if (Array.isArray(body.enabledLines)) {
+      newCfg.enabledLines = body.enabledLines.map((x) => String(x));
+    }
+    // lineNames is expected to be an object mapping lineId to string
+    if (body.lineNames && typeof body.lineNames === 'object') {
+      const names = {};
+      for (let i = 1; i <= 13; i++) {
+        const id = `line${i}`;
+        names[id] = String(body.lineNames[id] || settings.lineNames[id] || '');
+      }
+      newCfg.lineNames = names;
+    }
+    settings = newCfg;
+    // Persist the settings and update the agent
+    saveSettings(settings);
+    agent.updateSettings(settings);
+    res.json({ ok: true });
+  } catch (e) {
+    console.error('/settings/save', e);
+    res.status(500).json({ error: 'server' });
+  }
+});
+
+// -----------------------------------------------------------------------------
+// Miscellaneous
+
+// Health check endpoint.  Useful for container orchestration or
+// monitoring scripts.
+app.get('/healthz', (req, res) => {
+  res.json({ ok: true });
+});
+
+// Return the current server time for synchronisation or debugging.
+app.get('/time', (req, res) => {
+  res.json({ now: Math.floor(Date.now() / 1000) });
+});
+
+// -----------------------------------------------------------------------------
+// Offline watchdog
+
+// Periodically inspect each line and mark it as STOP if no packet has
+// been received within the configured offline timeout.  When a line
+// transitions from RUN to STOP as a result of the watchdog, a log
+// entry is recorded.  Note: the agent itself resets its smoothing
+// buffer in handleOffline().
+setInterval(() => {
+  const nowSec = Math.floor(Date.now() / 1000);
+  db.all(
+    `SELECT lineId,isRunning,lastPacketTime FROM status`,
+    (err, rows) => {
+      if (err || !rows) return;
+      rows.forEach((row) => {
+        const timeout = Number(settings.offlineTimeout) || 60;
+        if (row.lastPacketTime && nowSec - row.lastPacketTime > timeout) {
+          const changed = agent.handleOffline(row.lineId);
+          if (changed) {
+            // Update DB state and log the stop event
+            db.run(
+              `UPDATE status SET isRunning=0 WHERE lineId=?`,
+              [row.lineId],
+              () => {
+                db.run(
+                  `INSERT INTO status_log(lineId,timestamp,isRunning) VALUES (?,?,0)`,
+                  [row.lineId, nowSec, 0],
+                  () => {}
+                );
+              }
+            );
+          }
+        }
+      });
+    }
+  );
+}, 15000);
+
+// -----------------------------------------------------------------------------
+// Start the HTTP server
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
+app.listen(PORT, () => {
+  console.log(`HTTP server listening on port ${PORT}`);
+});

--- a/source/new_project/server.py
+++ b/source/new_project/server.py
@@ -1,0 +1,995 @@
+#!/usr/bin/env python3
+"""
+server.py
+
+This module implements a minimal HTTP server for the extrusion monitoring
+dashboard using Python's built‑in libraries.  It provides endpoints
+compatible with the required specification without relying on external
+packages such as Express.  State is persisted in an SQLite database and
+Excel reports are generated with openpyxl.  Sessions are handled via
+HTTP cookies stored in memory.
+"""
+
+import os
+import json
+import sqlite3
+import threading
+import time
+import uuid
+import urllib.parse
+import urllib.request
+from http import cookies
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler
+from socketserver import ThreadingTCPServer
+from urllib.parse import urlparse, parse_qs, unquote
+
+try:
+    import openpyxl
+except ImportError:
+    openpyxl = None
+
+# Determine base directories
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(BASE_DIR, 'data')
+PUBLIC_DIR = os.path.join(BASE_DIR, 'public')
+SETTINGS_PATH = os.path.join(BASE_DIR, 'config.json')
+
+# -----------------------------------------------------------------------------
+# Settings management
+
+def load_settings():
+    """Load runtime settings from config.json."""
+    try:
+        with open(SETTINGS_PATH, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def save_settings(cfg):
+    """Write settings back to config.json."""
+    tmp_path = SETTINGS_PATH + '.tmp'
+    with open(tmp_path, 'w', encoding='utf-8') as f:
+        json.dump(cfg, f, ensure_ascii=False, indent=2)
+    os.replace(tmp_path, SETTINGS_PATH)
+
+
+settings = load_settings()
+
+# -----------------------------------------------------------------------------
+# Database initialisation
+
+# Ensure the data directory exists
+os.makedirs(DATA_DIR, exist_ok=True)
+
+db = sqlite3.connect(os.path.join(DATA_DIR, 'data.db'), check_same_thread=False)
+db.row_factory = sqlite3.Row
+
+def init_db():
+    cur = db.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS status (
+            lineId TEXT PRIMARY KEY,
+            isRunning INTEGER DEFAULT 0,
+            lastPulseTime INTEGER DEFAULT 0,
+            lastPacketTime INTEGER DEFAULT 0
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS status_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            lineId TEXT,
+            timestamp INTEGER,
+            isRunning INTEGER,
+            productName TEXT
+        )
+        """
+    )
+    # Ensure productName column exists for backwards compatibility.  On
+    # older databases created before this column was introduced the
+    # column may be missing.  Use PRAGMA to introspect and add it
+    # dynamically.
+    cur.execute("PRAGMA table_info(status_log)")
+    cols = [row[1] for row in cur.fetchall()]
+    if 'productName' not in cols:
+        cur.execute('ALTER TABLE status_log ADD COLUMN productName TEXT')
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS pulses (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            lineId TEXT,
+            pulses INTEGER,
+            duration INTEGER,
+            timestamp INTEGER
+        )
+        """
+    )
+    # Seed 13 lines
+    for i in range(1, 14):
+        lid = f'line{i}'
+        cur.execute('INSERT OR IGNORE INTO status(lineId) VALUES (?)', (lid,))
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS minute_stats (
+            lineId TEXT,
+            ts INTEGER,
+            speed REAL,
+            PRIMARY KEY(lineId, ts)
+        )
+        """
+    )
+    db.commit()
+
+
+init_db()
+
+# -----------------------------------------------------------------------------
+# Agent implementation (smoothing and state detection)
+
+class Agent:
+    """Simple smoothing and state detection engine."""
+
+    def __init__(self, db_conn, config):
+        self.db = db_conn
+        self.settings = dict(config)
+        self.lines = {}
+        self.minute_map = {}
+        self.lock = threading.Lock()
+
+    def update_settings(self, new_cfg):
+        with self.lock:
+            self.settings.update(new_cfg or {})
+
+    def ingest(self, line_id, pulses, duration_ms, ts=None):
+        ts = int(ts) if ts is not None else int(time.time())
+        # convert ms timestamp
+        if ts > 1e12:
+            ts = ts // 1000
+        with self.lock:
+            line = self.lines.get(line_id)
+            if not line:
+                line = {
+                    'messages': [],
+                    'lastPacket': ts,
+                    'lastState': 0,
+                    'holdStart': 0,
+                    'holdStop': 0,
+                    'smoothedSpeed': 0.0,
+                }
+                self.lines[line_id] = line
+            # Append message
+            line['messages'].append({'pulses': pulses, 'duration': duration_ms, 'ts': ts})
+            line['lastPacket'] = ts
+            # Prune messages outside window
+            window_sec = int(self.settings.get('windowSec', 60))
+            cutoff = ts - window_sec
+            line['messages'] = [m for m in line['messages'] if m['ts'] >= cutoff]
+            # Compute smoothed speed
+            total_pulses = sum(m['pulses'] for m in line['messages'])
+            total_duration = sum(m['duration'] for m in line['messages'])
+            if total_duration > 0:
+                smoothed = (total_pulses / (total_duration / 1000.0)) * 60.0
+            else:
+                smoothed = 0.0
+            line['smoothedSpeed'] = smoothed
+            # State detection
+            V_START = float(self.settings.get('V_START', 0.5))
+            V_STOP = float(self.settings.get('V_STOP', 0.3))
+            delay_start = int(self.settings.get('delayStart', 30))
+            delay_stop = int(self.settings.get('delayStop', 30))
+            new_state = line['lastState']
+            if line['lastState'] == 1:
+                if smoothed <= V_STOP:
+                    if not line['holdStop']:
+                        line['holdStop'] = ts
+                    if ts - line['holdStop'] >= delay_stop:
+                        new_state = 0
+                        line['holdStop'] = 0
+                        line['holdStart'] = 0
+                else:
+                    line['holdStop'] = 0
+            else:
+                if smoothed >= V_START:
+                    if not line['holdStart']:
+                        line['holdStart'] = ts
+                    if ts - line['holdStart'] >= delay_start:
+                        new_state = 1
+                        line['holdStart'] = 0
+                        line['holdStop'] = 0
+                else:
+                    line['holdStart'] = 0
+            state_changed = new_state != line['lastState']
+            line['lastState'] = new_state
+            # Minute aggregation
+            minute_ts = (ts // 60) * 60
+            key = (line_id, minute_ts)
+            entry = self.minute_map.get(key)
+            if not entry:
+                entry = {'sum': 0.0, 'count': 0}
+                self.minute_map[key] = entry
+            entry['sum'] += smoothed
+            entry['count'] += 1
+            return smoothed, state_changed, new_state
+
+    def flush_minutes(self):
+        """Write aggregates older than the current minute to the database."""
+        with self.lock:
+            now_minute = (int(time.time()) // 60) * 60
+            keys = list(self.minute_map.keys())
+            for key in keys:
+                line_id, minute_ts = key
+                if minute_ts < now_minute:
+                    entry = self.minute_map.pop(key)
+                    avg = entry['sum'] / entry['count'] if entry['count'] > 0 else 0.0
+                    cur = self.db.cursor()
+                    cur.execute(
+                        'INSERT OR REPLACE INTO minute_stats(lineId, ts, speed) VALUES (?,?,?)',
+                        (line_id, minute_ts, avg)
+                    )
+                    cur.close()
+            self.db.commit()
+
+    def handle_offline(self, line_id):
+        """Reset smoothing for a line if no packets arrived within the timeout."""
+        with self.lock:
+            line = self.lines.get(line_id)
+            if not line:
+                return False
+            changed = False
+            line['messages'] = []
+            line['smoothedSpeed'] = 0.0
+            line['holdStart'] = 0
+            line['holdStop'] = 0
+            if line['lastState'] == 1:
+                line['lastState'] = 0
+                changed = True
+            return changed
+
+    def get_smoothed_speed(self, line_id):
+        with self.lock:
+            line = self.lines.get(line_id)
+            return line['smoothedSpeed'] if line else 0.0
+
+    def get_state(self, line_id):
+        with self.lock:
+            line = self.lines.get(line_id)
+            return line['lastState'] if line else 0
+
+    def get_series(self, line_id, hours):
+        """Return arrays of ISO timestamps and speeds for the last `hours` hours."""
+        now_ts = int(time.time())
+        to_minute = (now_ts // 60) * 60
+        from_minute = to_minute - int(hours) * 3600
+        cur = self.db.cursor()
+        cur.execute(
+            'SELECT ts, speed FROM minute_stats WHERE lineId=? AND ts>=? AND ts<=? ORDER BY ts ASC',
+            (line_id, from_minute, to_minute)
+        )
+        rows = cur.fetchall()
+        cur.close()
+        speed_map = {row['ts']: row['speed'] for row in rows}
+        labels = []
+        data = []
+        for t in range(from_minute, to_minute + 60, 60):
+            labels.append(time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(t)))
+            data.append(speed_map.get(t, None))
+        return {'labels': labels, 'data': data}
+
+    def get_daily_work_idle(self, line_id, days):
+        """Compute daily run/down durations for the last `days` days."""
+        now_ts = int(time.time())
+        to_ts = now_ts
+        from_ts = to_ts - days * 86400
+        cur = self.db.cursor()
+        # Fetch logs in range
+        cur.execute(
+            'SELECT timestamp, isRunning FROM status_log WHERE lineId=? AND timestamp>=? AND timestamp<=? ORDER BY timestamp ASC',
+            (line_id, from_ts, to_ts)
+        )
+        events = cur.fetchall()
+        # Fetch state before range
+        cur.execute(
+            'SELECT isRunning FROM status_log WHERE lineId=? AND timestamp<? ORDER BY timestamp DESC LIMIT 1',
+            (line_id, from_ts)
+        )
+        row = cur.fetchone()
+        cur.close()
+        initial_state = row['isRunning'] if row else 0
+        labels = []
+        work = []
+        down = []
+        prev_state = initial_state
+        # Iterate from oldest day to most recent
+        for d in range(days - 1, -1, -1):
+            day_start = ((to_ts - d * 86400) // 86400) * 86400
+            day_end = day_start + 86400
+            # events in this day
+            day_events = [e for e in events if day_start <= e['timestamp'] < day_end]
+            state = prev_state
+            seg_start = day_start
+            segments = []
+            for ev in day_events:
+                ev_state = int(ev['isRunning'])
+                if ev_state != state:
+                    segments.append({'start': seg_start, 'end': ev['timestamp'], 'state': state})
+                    state = ev_state
+                    seg_start = ev['timestamp']
+            segments.append({'start': seg_start, 'end': day_end, 'state': state})
+            prev_state = state
+            # merge short segments <60s
+            merged = []
+            for seg in segments:
+                dur = seg['end'] - seg['start']
+                if seg['state'] == 1 and dur < 60:
+                    # short run -> down
+                    if merged and merged[-1]['state'] == 0:
+                        merged[-1]['end'] = seg['end']
+                    else:
+                        merged.append({'start': seg['start'], 'end': seg['end'], 'state': 0})
+                elif seg['state'] == 0 and dur < 60:
+                    # short stop -> up
+                    if merged and merged[-1]['state'] == 1:
+                        merged[-1]['end'] = seg['end']
+                    else:
+                        merged.append({'start': seg['start'], 'end': seg['end'], 'state': 1})
+                else:
+                    merged.append(dict(seg))
+            run_sec = 0
+            down_sec = 0
+            for seg in merged:
+                dur = seg['end'] - seg['start']
+                if seg['state'] == 1:
+                    run_sec += dur
+                else:
+                    down_sec += dur
+            labels.append(time.strftime('%Y-%m-%d', time.gmtime(day_start)))
+            work.append(round(run_sec / 3600.0, 1))
+            down.append(round(down_sec / 3600.0, 1))
+        return {'labels': labels, 'work': work, 'down': down}
+
+
+agent = Agent(db, settings)
+
+# -----------------------------------------------------------------------------
+# Telegram helper
+
+def send_telegram_message(text):
+    """Send a notification via Telegram bot if credentials are set.
+
+    The message is sent asynchronously (fire‑and‑forget).  Errors are
+    suppressed to avoid disrupting the main flow.
+    """
+    token = settings.get('telegramToken')
+    chat_id = settings.get('telegramChatId')
+    if not token or not chat_id:
+        return
+    try:
+        # Build URL with URL‑encoded parameters
+        params = urllib.parse.urlencode({'chat_id': chat_id, 'text': text})
+        url = f"https://api.telegram.org/bot{token}/sendMessage?{params}"
+        # Fire request without blocking; ignore any returned data
+        with urllib.request.urlopen(url, timeout=10) as _:
+            pass
+    except Exception:
+        pass
+
+# -----------------------------------------------------------------------------
+# Session management
+
+SESSIONS = {}
+SESSION_LOCK = threading.Lock()
+
+def generate_sid():
+    return uuid.uuid4().hex
+
+def parse_cookies(header):
+    if not header:
+        return {}
+    c = cookies.SimpleCookie()
+    c.load(header)
+    return {k: morsel.value for k, morsel in c.items()}
+
+def get_session(handler):
+    header = handler.headers.get('Cookie')
+    jar = parse_cookies(header)
+    sid = jar.get('sid')
+    with SESSION_LOCK:
+        sess = SESSIONS.get(sid)
+        return sid, sess
+
+def set_session_cookie(handler, sid):
+    cookie = cookies.SimpleCookie()
+    cookie['sid'] = sid
+    cookie['sid']['path'] = '/'
+    # session cookie (no expiry)
+    handler.send_header('Set-Cookie', cookie.output(header=''))
+
+# -----------------------------------------------------------------------------
+# HTTP request handler
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = 'ExtrusionMonitor/1.0'
+
+    def end_headers(self):
+        # Allow CORS for local use if needed
+        self.send_header('Access-Control-Allow-Origin', '*')
+        super().end_headers()
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        path = parsed.path
+        # Public assets
+        if path.startswith('/public/'):
+            return self.serve_static(path[len('/public/'):])
+        # Health and time endpoints
+        if path == '/healthz':
+            return self.send_json({'ok': True})
+        if path == '/time':
+            return self.send_json({'now': int(time.time())})
+        # Login page
+        if path == '/login':
+            return self.serve_static('login.html')
+        # Report download proxies
+        if path == '/report/last30days':
+            # Redirect internally to report_clean
+            return self.handle_report_clean()
+        # Determine session
+        sid, sess = get_session(self)
+        # Handle unauthenticated access
+        if not sess or sess.get('user') != settings.get('loginUsername'):
+            # Only allow access to /login and static
+            if path in ('/login',) or path.startswith('/public/'):
+                return self.serve_static('login.html')
+            # Otherwise redirect to login
+            self.send_response(302)
+            self.send_header('Location', '/login')
+            self.end_headers()
+            return
+        # Authenticated from here on
+        if path == '/':
+            return self.serve_static('index.html')
+        if path == '/status':
+            return self.handle_status()
+        if path.startswith('/chartdata/'):
+            line_id = path[len('/chartdata/'):]
+            return self.handle_chartdata(line_id)
+        if path == '/report':
+            return self.handle_report(parsed.query)
+        if path == '/report_clean':
+            return self.handle_report_clean()
+        if path == '/settings':
+            return self.serve_static('settings.html')
+        if path == '/settings/info':
+            return self.handle_settings_info(sess)
+        # Fallback 404
+        self.send_response(404)
+        self.end_headers()
+        self.wfile.write(b'Not found')
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        path = parsed.path
+        length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(length) if length > 0 else b''
+        content_type = self.headers.get('Content-Type', '')
+        data = {}
+        if content_type.startswith('application/json'):
+            try:
+                data = json.loads(body.decode('utf-8') or '{}')
+            except Exception:
+                data = {}
+        elif content_type.startswith('application/x-www-form-urlencoded'):
+            qs = parse_qs(body.decode('utf-8'))
+            data = {k: v[0] for k, v in qs.items()}
+        # Handle login separately as it doesn't require session
+        if path == '/login':
+            return self.handle_login(data)
+        # Session check
+        sid, sess = get_session(self)
+        if not sess or sess.get('user') != settings.get('loginUsername'):
+            self.send_response(401)
+            self.end_headers()
+            self.wfile.write(b'Unauthorized')
+            return
+        if path == '/data':
+            return self.handle_data(data)
+        if path == '/settings/auth':
+            return self.handle_settings_auth(data, sid, sess)
+        if path == '/settings/save':
+            return self.handle_settings_save(data, sid, sess)
+        # Unknown POST
+        self.send_response(404)
+        self.end_headers()
+        self.wfile.write(b'Not found')
+
+    # ---------------------------------------------------------------------
+    # Static file serving
+    def serve_static(self, rel_path):
+        # Prevent directory traversal
+        safe_path = os.path.normpath(rel_path).lstrip('/\\')
+        abs_path = os.path.join(PUBLIC_DIR, safe_path)
+        if not abs_path.startswith(PUBLIC_DIR):
+            self.send_response(403)
+            self.end_headers()
+            self.wfile.write(b'Forbidden')
+            return
+        if not os.path.isfile(abs_path):
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b'Not found')
+            return
+        ext = os.path.splitext(abs_path)[1].lower()
+        mime = 'text/plain'
+        if ext == '.html':
+            mime = 'text/html; charset=utf-8'
+        elif ext == '.css':
+            mime = 'text/css'
+        elif ext == '.js':
+            mime = 'application/javascript'
+        elif ext in ('.png', '.jpg', '.jpeg', '.gif', '.webp'):
+            mime = f'image/{ext[1:]}'
+        elif ext == '.svg':
+            mime = 'image/svg+xml'
+        try:
+            with open(abs_path, 'rb') as f:
+                content = f.read()
+            self.send_response(200)
+            self.send_header('Content-Type', mime)
+            self.send_header('Content-Length', str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+        except Exception:
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(b'Error')
+
+    # ---------------------------------------------------------------------
+    # Response helpers
+    def send_json(self, obj, status=200):
+        body = json.dumps(obj, ensure_ascii=False).encode('utf-8')
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json; charset=utf-8')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    # ---------------------------------------------------------------------
+    # POST handlers
+    def handle_login(self, data):
+        username_in = str(data.get('username', ''))
+        password_in = str(data.get('password', ''))
+        if (username_in == settings.get('loginUsername') and password_in == settings.get('loginPassword')):
+            # create session
+            sid = generate_sid()
+            with SESSION_LOCK:
+                SESSIONS[sid] = {'user': username_in, 'settingsAuth': False}
+            self.send_response(302)
+            set_session_cookie(self, sid)
+            self.send_header('Location', '/')
+            self.end_headers()
+            return
+        # Invalid credentials
+        self.send_response(401)
+        self.end_headers()
+        self.wfile.write(b'Unauthorized')
+
+    def handle_data(self, data):
+        line_id = str(data.get('lineId', '')).strip()
+        pulses = data.get('pulses')
+        duration = data.get('duration')
+        ts = data.get('ts')
+        try:
+            p = int(pulses)
+            dur = int(duration)
+        except Exception:
+            return self.send_json({'error': 'invalid payload'}, status=400)
+        if not line_id or dur <= 0:
+            return self.send_json({'error': 'invalid payload'}, status=400)
+        # Insert raw packet
+        pkt_ts = int(ts) if ts is not None else int(time.time())
+        if pkt_ts > 1e12:
+            pkt_ts = pkt_ts // 1000
+        cur = db.cursor()
+        cur.execute(
+            'INSERT INTO pulses(lineId,pulses,duration,timestamp) VALUES (?,?,?,?)',
+            (line_id, p, dur, pkt_ts)
+        )
+        # Ensure line exists
+        cur.execute('INSERT OR IGNORE INTO status(lineId) VALUES (?)', (line_id,))
+        db.commit()
+        # Feed agent
+        smoothed, state_changed, new_state = agent.ingest(line_id, p, dur, ts)
+        now_sec = int(time.time())
+        # Update status table
+        sets = ['lastPacketTime=?']
+        params = [now_sec]
+        if p > 0:
+            sets.append('lastPulseTime=?')
+            params.append(now_sec)
+        if state_changed:
+            sets.append('isRunning=?')
+            params.append(int(new_state))
+        params.append(line_id)
+        cur.execute(f'UPDATE status SET {", ".join(sets)} WHERE lineId=?', params)
+        if state_changed:
+            # Capture current product for this line when logging the event
+            product_name = settings.get('products', {}).get(line_id, '')
+            cur.execute(
+                'INSERT INTO status_log(lineId,timestamp,isRunning,productName) VALUES (?,?,?,?)',
+                (line_id, now_sec, int(new_state), product_name)
+            )
+            # Send Telegram notification (fire and forget)
+            display_name = settings.get('lineNames', {}).get(line_id, line_id)
+            if int(new_state) == 1:
+                action = 'запуск'
+            else:
+                action = 'остановка'
+            msg = f"Линия {display_name} (изделие: {product_name}): {action}"
+            send_telegram_message(msg)
+        db.commit()
+        return self.send_json({'ok': True})
+
+    def handle_settings_auth(self, data, sid, sess):
+        password = str(data.get('password', ''))
+        settings_pass = settings.get('settingsPassword', '19910509')
+        if password == settings_pass:
+            with SESSION_LOCK:
+                sess['settingsAuth'] = True
+            return self.send_json({'ok': True})
+        return self.send_json({'error': 'wrong password'}, status=401)
+
+    def handle_settings_save(self, data, sid, sess):
+        # Persist new settings from the settings UI.  Since this handler
+        # modifies the module‑level ``settings`` object it must declare
+        # ``settings`` as global at the beginning of the function.  Python
+        # requires the global statement before any use of the variable in
+        # the function scope.
+        global settings
+        if not sess.get('settingsAuth'):
+            return self.send_json({'error': 'unauthorized'}, status=401)
+        # build new config
+        new_cfg = dict(settings)
+        def to_num(v, default):
+            try:
+                n = float(v)
+                if n >= 0:
+                    return n
+            except Exception:
+                pass
+            return default
+        new_cfg['windowSec'] = int(to_num(data.get('windowSec'), settings.get('windowSec', 60)))
+        new_cfg['V_START'] = float(to_num(data.get('V_START'), settings.get('V_START', 0.5)))
+        new_cfg['V_STOP'] = float(to_num(data.get('V_STOP'), settings.get('V_STOP', 0.3)))
+        new_cfg['delayStart'] = int(to_num(data.get('delayStart'), settings.get('delayStart', 30)))
+        new_cfg['delayStop'] = int(to_num(data.get('delayStop'), settings.get('delayStop', 30)))
+        gh = int(to_num(data.get('graphHours'), settings.get('graphHours', 24)))
+        new_cfg['graphHours'] = gh if gh in (24, 48) else settings.get('graphHours', 24)
+        new_cfg['offlineTimeout'] = int(to_num(data.get('offlineTimeout'), settings.get('offlineTimeout', 60)))
+        if isinstance(data.get('enabledLines'), list):
+            new_cfg['enabledLines'] = [str(x) for x in data.get('enabledLines')]
+        if isinstance(data.get('lineNames'), dict):
+            names = {}
+            for i in range(1, 14):
+                lid = f'line{i}'
+                names[lid] = str(data['lineNames'].get(lid, settings.get('lineNames', {}).get(lid, '')))
+            new_cfg['lineNames'] = names
+        # Update product names
+        if isinstance(data.get('products'), dict):
+            prods = {}
+            for i in range(1, 14):
+                lid = f'line{i}'
+                prods[lid] = str(data['products'].get(lid, settings.get('products', {}).get(lid, '')))
+            new_cfg['products'] = prods
+        # Update Telegram credentials
+        if 'telegramToken' in data:
+            new_cfg['telegramToken'] = str(data.get('telegramToken') or settings.get('telegramToken', ''))
+        if 'telegramChatId' in data:
+            new_cfg['telegramChatId'] = str(data.get('telegramChatId') or settings.get('telegramChatId', ''))
+        # Preserve credentials and settings password
+        new_cfg['loginUsername'] = settings.get('loginUsername')
+        new_cfg['loginPassword'] = settings.get('loginPassword')
+        new_cfg['settingsPassword'] = settings.get('settingsPassword')
+        # Apply and persist
+        settings = new_cfg
+        save_settings(settings)
+        agent.update_settings(settings)
+        return self.send_json({'ok': True})
+
+    # ---------------------------------------------------------------------
+    # GET handlers
+    def handle_status(self):
+        # Return status for all 13 lines
+        cur = db.cursor()
+        cur.execute('SELECT lineId,isRunning,lastPulseTime,lastPacketTime FROM status ORDER BY lineId ASC')
+        rows = cur.fetchall()
+        cur.close()
+        now_sec = int(time.time())
+        result = []
+        for i in range(1, 14):
+            lid = f'line{i}'
+            row = next((r for r in rows if r['lineId'] == lid), None)
+            if not row:
+                row = {'lineId': lid, 'isRunning': 0, 'lastPulseTime': 0, 'lastPacketTime': 0}
+            smoothed = agent.get_smoothed_speed(lid)
+            state = agent.get_state(lid)
+            # Determine label
+            offline = True
+            if row['lastPacketTime'] and now_sec - row['lastPacketTime'] <= settings.get('offlineTimeout', 60):
+                offline = False
+            if offline or row['lastPacketTime'] == 0:
+                label = 'нет данных'
+            else:
+                label = 'Работает' if state == 1 else 'Остановлена'
+            disp = settings.get('lineNames', {}).get(lid, lid)
+            result.append({
+                'lineId': lid,
+                'displayName': disp,
+                'speed': smoothed,
+                'isRunning': bool(state),
+                'lastPulseTime': row['lastPulseTime'],
+                'lastPacketTime': row['lastPacketTime'],
+                'stateLabel': label,
+                'product': settings.get('products', {}).get(lid, '')
+            })
+        return self.send_json(result)
+
+    def handle_chartdata(self, line_id):
+        hours = int(settings.get('graphHours', 24))
+        series = agent.get_series(line_id, hours)
+        daily = agent.get_daily_work_idle(line_id, 30)
+        line_name = settings.get('lineNames', {}).get(line_id, line_id)
+        return self.send_json({'speed': series, 'status': {**daily, 'lineName': line_name}})
+
+    def handle_settings_info(self, sess):
+        if not sess.get('settingsAuth'):
+            return self.send_json({'error': 'unauthorized'}, status=401)
+        return self.send_json(settings)
+
+    def handle_report(self, query):
+        if openpyxl is None:
+            return self.send_json({'error': 'excel unavailable'}, status=500)
+        # parse from and to from query params
+        params = parse_qs(query or '')
+        def parse_date(val):
+            try:
+                return int(datetime.datetime.fromisoformat(val).timestamp())
+            except Exception:
+                return None
+        to_ts = None
+        from_ts = None
+        if 'to' in params:
+            to_ts = parse_date(params['to'][0])
+        if 'from' in params:
+            from_ts = parse_date(params['from'][0])
+        now_sec = int(time.time())
+        if to_ts is None:
+            to_ts = now_sec
+        if from_ts is None:
+            from_ts = to_ts - 30 * 86400
+        # Build workbook
+        wb = openpyxl.Workbook()
+        summary = wb.active
+        summary.title = 'Сводка 30 дней'
+        summary.append(['Линия', 'Работа, ч', 'Простой, ч', '% простоя'])
+        lines = [f'line{i}' for i in range(1, 14)]
+        for lid in lines:
+            sheet = wb.create_sheet(title=lid)
+            # Add a column for the product (номенклатура)
+            sheet.append(['Дата', 'Событие', 'Время', 'Простой, мин', 'Номенклатура'])
+            # initial state
+            cur = db.cursor()
+            cur.execute('SELECT isRunning FROM status_log WHERE lineId=? AND timestamp<? ORDER BY timestamp DESC LIMIT 1', (lid, from_ts))
+            row = cur.fetchone()
+            initial = row['isRunning'] if row else 0
+            # logs
+            cur.execute('SELECT timestamp,isRunning,productName FROM status_log WHERE lineId=? AND timestamp>=? AND timestamp<=? ORDER BY timestamp ASC', (lid, from_ts, to_ts))
+            events = cur.fetchall()
+            cur.close()
+            total_run = 0
+            total_down = 0
+            prev_state = initial
+            # Determine last known product before the reporting period
+            cur = db.cursor()
+            cur.execute('SELECT productName FROM status_log WHERE lineId=? AND timestamp<? ORDER BY timestamp DESC LIMIT 1', (lid, from_ts))
+            row = cur.fetchone()
+            cur.close()
+            prev_product = row['productName'] if row and row['productName'] is not None else settings.get('products', {}).get(lid, '')
+            # iterate days
+            t = from_ts - (from_ts % 86400)
+            while t < to_ts:
+                day_start = t
+                day_end = min(t + 86400, to_ts)
+                day_label = time.strftime('%Y-%m-%d', time.gmtime(day_start))
+                day_events = [e for e in events if day_start <= e['timestamp'] < day_end]
+                state = prev_state
+                seg_start = day_start
+                segments = []
+                for ev in day_events:
+                    ev_state = int(ev['isRunning'])
+                    ev_prod = ev['productName']
+                    if ev_state != state:
+                        # close previous segment, annotate with current product
+                        segments.append({'start': seg_start, 'end': ev['timestamp'], 'state': state, 'product': prev_product})
+                        # update state and product for next segment
+                        state = ev_state
+                        seg_start = ev['timestamp']
+                        if ev_prod is not None:
+                            prev_product = ev_prod
+                    elif ev_prod:
+                        # product changed without state change
+                        segments.append({'start': seg_start, 'end': ev['timestamp'], 'state': state, 'product': prev_product})
+                        seg_start = ev['timestamp']
+                        prev_product = ev_prod
+                # final segment
+                segments.append({'start': seg_start, 'end': day_end, 'state': state, 'product': prev_product})
+                prev_state = state
+                # merge short segments
+                merged = []
+                for seg in segments:
+                    dur = seg['end'] - seg['start']
+                    # If a short RUN segment (<60s), merge into previous STOP segment
+                    if seg['state'] == 1 and dur < 60:
+                        if merged and merged[-1]['state'] == 0:
+                            merged[-1]['end'] = seg['end']
+                        else:
+                            # convert this run into down time
+                            merged.append({'start': seg['start'], 'end': seg['end'], 'state': 0, 'product': seg.get('product')})
+                    # If a short STOP segment (<60s), merge into previous RUN segment
+                    elif seg['state'] == 0 and dur < 60:
+                        if merged and merged[-1]['state'] == 1:
+                            merged[-1]['end'] = seg['end']
+                        else:
+                            merged.append({'start': seg['start'], 'end': seg['end'], 'state': 1, 'product': seg.get('product')})
+                    else:
+                        merged.append(dict(seg))
+                # write rows
+                for i, seg in enumerate(merged):
+                    dur_min = int(round((seg['end'] - seg['start']) / 60))
+                    prod = seg.get('product', '')
+                    if seg['state'] == 1:
+                        total_run += seg['end'] - seg['start']
+                        # Работа
+                        sheet.append([
+                            day_label,
+                            'Работа',
+                            time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(seg['start'])),
+                            str(dur_min),
+                            prod
+                        ])
+                        # Остановка marker
+                        sheet.append([
+                            day_label,
+                            'Остановка',
+                            time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(seg['end'])),
+                            '',
+                            prod
+                        ])
+                    else:
+                        total_down += seg['end'] - seg['start']
+                        # Простой
+                        sheet.append([
+                            day_label,
+                            'Простой',
+                            time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(seg['start'])),
+                            str(dur_min),
+                            prod
+                        ])
+                        if i < len(merged) - 1 and merged[i + 1]['state'] == 1:
+                            # Запуск marker at end of stop
+                            sheet.append([
+                                day_label,
+                                'Запуск',
+                                time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(seg['end'])),
+                                '',
+                                prod
+                            ])
+                t += 86400
+            total = total_run + total_down
+            pct = f"{(total_down / total * 100):.1f}%" if total > 0 else '0.0%'
+            summary.append([lid, f"{total_run / 3600:.1f}", f"{total_down / 3600:.1f}", pct])
+        # Remove default sheet if it exists beyond summary
+        # Save workbook to bytes
+        from io import BytesIO
+        output = BytesIO()
+        wb.save(output)
+        data = output.getvalue()
+        output.close()
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+        self.send_header('Content-Disposition', 'attachment; filename="report.xlsx"')
+        self.send_header('Content-Length', str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def handle_report_clean(self):
+        if openpyxl is None:
+            return self.send_json({'error': 'excel unavailable'}, status=500)
+        wb = openpyxl.Workbook()
+        summary = wb.active
+        summary.title = 'Сводка 30 дней'
+        summary.append(['Линия', 'Работа, ч', 'Простой, ч', '% простоя'])
+        lines = [f'line{i}' for i in range(1, 14)]
+        for lid in lines:
+            daily = agent.get_daily_work_idle(lid, 30)
+            sheet = wb.create_sheet(title=lid)
+            sheet.append(['Дата', 'Работа, ч', 'Простой, ч'])
+            run_total = 0.0
+            down_total = 0.0
+            for lbl, up, down in zip(daily['labels'], daily['work'], daily['down']):
+                sheet.append([lbl, up, down])
+                run_total += up
+                down_total += down
+            total = run_total + down_total
+            pct = f"{(down_total / total * 100):.1f}%" if total > 0 else '0.0%'
+            summary.append([lid, f"{run_total:.1f}", f"{down_total:.1f}", pct])
+        # Save workbook
+        from io import BytesIO
+        output = BytesIO()
+        wb.save(output)
+        data = output.getvalue()
+        output.close()
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+        self.send_header('Content-Disposition', 'attachment; filename="report_30days_clean.xlsx"')
+        self.send_header('Content-Length', str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+# -----------------------------------------------------------------------------
+# Background flush and offline watchdog
+
+def background_worker():
+    while True:
+        try:
+            # flush minute aggregates
+            agent.flush_minutes()
+            # offline detection
+            now_sec = int(time.time())
+            cur = db.cursor()
+            cur.execute('SELECT lineId,isRunning,lastPacketTime FROM status')
+            rows = cur.fetchall()
+            cur.close()
+            for row in rows:
+                lid = row['lineId']
+                timeout = int(settings.get('offlineTimeout', 60))
+                if row['lastPacketTime'] and now_sec - row['lastPacketTime'] > timeout:
+                    changed = agent.handle_offline(lid)
+                    if changed:
+                        c = db.cursor()
+                        c.execute('UPDATE status SET isRunning=0 WHERE lineId=?', (lid,))
+                        # Log stop event with current product when offline timeout triggers
+                        product_name = settings.get('products', {}).get(lid, '')
+                        c.execute(
+                            'INSERT INTO status_log(lineId,timestamp,isRunning,productName) VALUES (?,?,?,?)',
+                            (lid, now_sec, 0, product_name)
+                        )
+                        # Telegram notification
+                        display_name = settings.get('lineNames', {}).get(lid, lid)
+                        msg = f"Линия {display_name} (изделие: {product_name}): остановка (нет данных)"
+                        send_telegram_message(msg)
+                        c.close()
+                        db.commit()
+        except Exception:
+            pass
+        time.sleep(15)
+
+
+# Start background thread
+threading.Thread(target=background_worker, daemon=True).start()
+
+# -----------------------------------------------------------------------------
+# Launch the server
+
+def run_server(port=3000):
+    with ThreadingTCPServer(('0.0.0.0', port), Handler) as httpd:
+        print(f'Server running on port {port}')
+        httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    run_server(int(os.environ.get('PORT', '3000')))

--- a/source/new_project/smartAgent.js
+++ b/source/new_project/smartAgent.js
@@ -1,0 +1,414 @@
+/*
+ * smartAgent.js
+ *
+ * A lightweight smoothing and state detection module for the extrusion
+ * monitoring system.  It ingests pulse packets from the ESP32, applies
+ * a sliding‑window average to compute a smoothed speed and determines
+ * whether each line is running or stopped using configurable thresholds
+ * and delays.  The agent also produces minute‑level speed aggregates
+ * for charting and exposes helper methods to compute daily uptime and
+ * downtime from the recorded event log.
+ */
+
+const sqlite3 = require('sqlite3').verbose();
+
+const pad = (n) => String(n).padStart(2, '0');
+function formatDateTime(ts) {
+  const d = new Date(ts * 1000);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+function formatDate(ts) {
+  const d = new Date(ts * 1000);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+function formatTime(ts) {
+  const d = new Date(ts * 1000);
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+class Agent {
+  /**
+   * Construct a new Agent.
+   *
+   * @param {sqlite3.Database} db          SQLite connection used to
+   *                                       persist minute aggregates.
+   * @param {Object} settings              Initial smoothing and state
+   *                                       detection parameters.
+   */
+  constructor(db, settings) {
+    this.db = db;
+    // Copy settings so that subsequent updates don't mutate the
+    // originally passed object.
+    this.settings = Object.assign({}, settings);
+    // Per‑line state.  Each key stores an object with the following
+    // fields:
+    //   messages: array of recent packets { pulses, duration, ts }
+    //   lastPacket: timestamp of the most recent packet (seconds)
+    //   lastState: 1 for RUN, 0 for STOP
+    //   holdStart: timestamp when we began counting towards a RUN change
+    //   holdStop:  timestamp when we began counting towards a STOP change
+    //   smoothedSpeed: latest computed smoothed speed (cm/min)
+    this.lines = {};
+    // Map used to accumulate per‑minute speed aggregates before they are
+    // flushed to disk.  Keys are `${lineId}_${minuteTs}` and values
+    // contain { sum, count }.
+    this.minuteMap = {};
+    // Create the minute_stats table for storing per‑minute speeds.  We
+    // avoid creating this table inside ingest() to minimise the cost on
+    // the critical path.
+    this.db.serialize(() => {
+      this.db.run(
+        `CREATE TABLE IF NOT EXISTS minute_stats (
+          lineId TEXT,
+          ts INTEGER,
+          speed REAL,
+          PRIMARY KEY(lineId, ts)
+        )`
+      );
+    });
+    // Periodically flush stale minute aggregates to the database.  The
+    // flush interval is deliberately short so that charts show recent
+    // values without significant lag.
+    setInterval(() => this.flushMinuteData(), 10000);
+  }
+
+  /**
+   * Update the smoothing and state detection parameters at runtime.  The
+   * provided object replaces the existing settings; any missing
+   * properties retain their previous values.
+   *
+   * @param {Object} newSettings Updated settings.
+   */
+  updateSettings(newSettings) {
+    this.settings = Object.assign({}, this.settings, newSettings || {});
+  }
+
+  /**
+   * Ingest a single pulse packet.  The caller is responsible for
+   * persisting raw packet data and updating the status table.  This
+   * method updates the internal smoothing buffer, computes the
+   * smoothed speed and determines whether the line has transitioned
+   * between RUN and STOP.  It returns information about the new state
+   * so that the caller can update the database accordingly.
+   *
+   * @param {String} lineId Identifier of the monitored line.
+   * @param {Object} pkt    Packet with fields:
+   *   pulses   {Number}  Number of pulses counted in the sampling period.
+   *   duration {Number}  Duration of the sampling period in milliseconds.
+   *   ts       {Number}  Optional UNIX timestamp in seconds; if omitted
+   *                      the current time is used.
+   * @returns {Object} { smoothedSpeed, stateChanged, newState }
+   */
+  ingest(lineId, pkt) {
+    const pulses = Number(pkt.pulses) || 0;
+    const durationMs = Number(pkt.duration) || 0;
+    // Normalize timestamp: accept seconds or milliseconds.  When a
+    // millisecond epoch is provided the value will exceed 1e12.
+    let ts = Number(pkt.ts);
+    if (!ts || isNaN(ts)) ts = Math.floor(Date.now() / 1000);
+    else if (ts > 1e12) ts = Math.floor(ts / 1000);
+    const line = this.lines[lineId] || {
+      messages: [],
+      lastPacket: ts,
+      lastState: 0,
+      holdStart: 0,
+      holdStop: 0,
+      smoothedSpeed: 0,
+    };
+    this.lines[lineId] = line;
+    // Append the new packet and prune old entries outside the sliding
+    // window.  We keep the raw pulses and durations in order to
+    // compute a weighted average later on.
+    line.messages.push({ pulses, duration: durationMs, ts });
+    line.lastPacket = ts;
+    const windowSec = Number(this.settings.windowSec) || 60;
+    const cutoff = ts - windowSec;
+    line.messages = line.messages.filter(m => m.ts >= cutoff);
+    // Compute the weighted average speed.  The speed for a single
+    // packet is (pulses / durationMs) * 60000 = cm/min (since 1 pulse
+    // equals 1 cm).  To average over the window we sum all pulses and
+    // durations and apply the same formula.
+    let sumPulses = 0;
+    let sumDuration = 0;
+    for (const m of line.messages) {
+      sumPulses += m.pulses;
+      sumDuration += m.duration;
+    }
+    let smoothedSpeed = 0;
+    if (sumDuration > 0) {
+      smoothedSpeed = (sumPulses / (sumDuration / 1000)) * 60;
+    }
+    line.smoothedSpeed = smoothedSpeed;
+    // State detection.  We implement a simple hysteresis: when the
+    // smoothed speed rises above V_START and remains there for
+    // delayStart seconds the line is considered running.  When the
+    // smoothed speed falls below V_STOP and remains there for
+    // delayStop seconds it is considered stopped.  When in either
+    // state, the opposing hold timer is reset if the speed crosses
+    // back over the opposite threshold.
+    const V_START = Number(this.settings.V_START) || 0.5;
+    const V_STOP = Number(this.settings.V_STOP) || 0.3;
+    const delayStart = Number(this.settings.delayStart) || 30;
+    const delayStop = Number(this.settings.delayStop) || 30;
+    let newState = line.lastState;
+    if (line.lastState === 1) {
+      // Currently running; look for stop condition.
+      if (smoothedSpeed <= V_STOP) {
+        if (!line.holdStop) line.holdStop = ts;
+        if (ts - line.holdStop >= delayStop) {
+          newState = 0;
+          line.holdStop = 0;
+          line.holdStart = 0;
+        }
+      } else {
+        // Speed recovered; reset stop hold timer.
+        line.holdStop = 0;
+      }
+    } else {
+      // Currently stopped; look for run condition.
+      if (smoothedSpeed >= V_START) {
+        if (!line.holdStart) line.holdStart = ts;
+        if (ts - line.holdStart >= delayStart) {
+          newState = 1;
+          line.holdStart = 0;
+          line.holdStop = 0;
+        }
+      } else {
+        // Speed dropped; reset run hold timer.
+        line.holdStart = 0;
+      }
+    }
+    const stateChanged = newState !== line.lastState;
+    line.lastState = newState;
+    // Aggregate the smoothed speed per minute.  We maintain a map of
+    // aggregates keyed by `${lineId}_${minuteTs}`.  The minute
+    // timestamp is truncated to the start of the minute.  Each entry
+    // accumulates the smoothed speed and a sample count.  Later a
+    // periodic flush writes these entries to minute_stats.
+    const minuteTs = Math.floor(ts / 60) * 60;
+    const mapKey = `${lineId}_${minuteTs}`;
+    const entry = this.minuteMap[mapKey] || { sum: 0, count: 0 };
+    entry.sum += smoothedSpeed;
+    entry.count += 1;
+    this.minuteMap[mapKey] = entry;
+    return { smoothedSpeed, stateChanged, newState };
+  }
+
+  /**
+   * Flush stale minute aggregates to the database.  Aggregates older
+   * than one minute ago are written to minute_stats and removed from
+   * the in‑memory map.  This method is invoked periodically by a
+   * timer set up in the constructor.
+   */
+  flushMinuteData() {
+    const now = Math.floor(Date.now() / 1000);
+    const currentMinute = Math.floor(now / 60) * 60;
+    const keys = Object.keys(this.minuteMap);
+    for (const key of keys) {
+      const [lineId, tsStr] = key.split('_');
+      const minuteTs = parseInt(tsStr, 10);
+      // Only flush minutes older than the most recent complete minute.
+      if (minuteTs < currentMinute) {
+        const entry = this.minuteMap[key];
+        const avg = entry.count > 0 ? entry.sum / entry.count : 0;
+        this.db.run(
+          `INSERT OR REPLACE INTO minute_stats(lineId, ts, speed) VALUES (?,?,?)`,
+          [lineId, minuteTs, avg],
+          () => {}
+        );
+        delete this.minuteMap[key];
+      }
+    }
+  }
+
+  /**
+   * Reset a line when no packets have arrived for the configured
+   * offlineTimeout.  The smoothing buffer is cleared, the speed is
+   * reset to zero and the state transitions to STOP.  The caller is
+   * responsible for updating the database if a state change occurs.
+   *
+   * @param {String} lineId Identifier of the line to reset.
+   * @returns {Boolean} True if the line transitioned from RUN to STOP.
+   */
+  handleOffline(lineId) {
+    const line = this.lines[lineId];
+    if (!line) return false;
+    let changed = false;
+    // Clear the smoothing buffer and timers.
+    line.messages = [];
+    line.smoothedSpeed = 0;
+    line.holdStart = 0;
+    line.holdStop = 0;
+    if (line.lastState === 1) {
+      line.lastState = 0;
+      changed = true;
+    }
+    return changed;
+  }
+
+  /**
+   * Retrieve the latest smoothed speed for a line.  If no data has been
+   * received the speed is zero.
+   *
+   * @param {String} lineId Identifier of the line.
+   * @returns {Number} Smoothed speed (cm/min).
+   */
+  getSmoothedSpeed(lineId) {
+    const line = this.lines[lineId];
+    return line ? line.smoothedSpeed : 0;
+  }
+
+  /**
+   * Retrieve the last known state for a line.  1 represents RUN and 0
+   * represents STOP.
+   *
+   * @param {String} lineId Identifier of the line.
+   * @returns {Number} The current state.
+   */
+  getState(lineId) {
+    const line = this.lines[lineId];
+    return line ? line.lastState : 0;
+  }
+
+  /**
+   * Fetch a time series of smoothed speeds for the given number of
+   * hours.  The method reads from the minute_stats table and fills in
+   * missing minutes with null values so that Chart.js draws gaps.
+   *
+   * @param {String} lineId Identifier of the line.
+   * @param {Number} hours  Number of hours of history to return.
+   * @param {Function} cb   Callback (err, { labels, data }).
+   */
+  getSeries(lineId, hours, cb) {
+    const now = Math.floor(Date.now() / 1000);
+    const toMinute = Math.floor(now / 60) * 60;
+    const fromMinute = toMinute - hours * 3600;
+    this.db.all(
+      `SELECT ts, speed FROM minute_stats WHERE lineId=? AND ts>=? AND ts<=? ORDER BY ts ASC`,
+      [lineId, fromMinute, toMinute],
+      (err, rows) => {
+        if (err) return cb(err);
+        const map = {};
+        for (const r of rows) {
+          map[r.ts] = r.speed;
+        }
+        const labels = [];
+        const data = [];
+        for (let t = fromMinute; t <= toMinute; t += 60) {
+          labels.push(formatDateTime(t));
+          if (map.hasOwnProperty(t)) data.push(map[t]);
+          else data.push(null);
+        }
+        cb(null, { labels, data });
+      }
+    );
+  }
+
+  /**
+   * Compute daily uptime and downtime for a line.  The algorithm uses
+   * the status_log table to determine RUN/STOP segments and merges
+   * segments shorter than 60 seconds into the opposite state.  The
+   * returned arrays contain one entry per day, starting from the most
+   * recent day and going back `days` days.  All durations are
+   * expressed in hours with one decimal place.
+   *
+   * @param {String} lineId Identifier of the line.
+   * @param {Number} days   Number of days to return (e.g. 30).
+   * @param {Function} cb   Callback (err, { labels, work, down }).
+   */
+  getDailyWorkIdle(lineId, days, cb) {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const to = nowSec;
+    const from = to - days * 86400;
+    // Fetch logs for the relevant period and the last state before the
+    // period to determine the initial state.
+    this.db.all(
+      `SELECT timestamp, isRunning FROM status_log WHERE lineId=? AND timestamp>=? AND timestamp<=? ORDER BY timestamp ASC`,
+      [lineId, from, to],
+      (err, rows) => {
+        if (err) return cb(err);
+        this.db.get(
+          `SELECT isRunning FROM status_log WHERE lineId=? AND timestamp<? ORDER BY timestamp DESC LIMIT 1`,
+          [lineId, from],
+          (err2, lastRow) => {
+            if (err2) return cb(err2);
+            let initialState = lastRow ? Number(lastRow.isRunning) : 0;
+            const labels = [];
+            const work = [];
+            const down = [];
+            const events = [];
+            // We'll iterate from the oldest day to the most recent so
+            // that the resulting arrays line up with ascending dates.
+            for (let d = days - 1; d >= 0; d--) {
+              const dayStart = Math.floor((to - d * 86400) / 86400) * 86400;
+              const dayEnd = dayStart + 86400;
+              const dayLogs = rows.filter(r => r.timestamp >= dayStart && r.timestamp < dayEnd);
+              // Build raw segments within this day.
+              let segState = initialState;
+              let segStart = dayStart;
+              const segments = [];
+              for (const ev of dayLogs) {
+                if (Number(ev.isRunning) !== segState) {
+                  segments.push({ start: segStart, end: ev.timestamp, state: segState });
+                  segState = Number(ev.isRunning);
+                  segStart = ev.timestamp;
+                }
+              }
+              segments.push({ start: segStart, end: dayEnd, state: segState });
+              // Update initialState for the next iteration (previous day)
+              initialState = segments.length > 0 ? segments[segments.length - 1].state : initialState;
+              // Merge short segments (<60 seconds).  Runs shorter than
+              // 60 seconds are treated as downtime; stops shorter than
+              // 60 seconds are treated as uptime.
+              const merged = [];
+              for (const seg of segments) {
+                const dur = seg.end - seg.start;
+                if (seg.state === 1 && dur < 60) {
+                  // Short run; merge into downtime
+                  if (merged.length && merged[merged.length - 1].state === 0) {
+                    merged[merged.length - 1].end = seg.end;
+                  } else {
+                    merged.push({ start: seg.start, end: seg.end, state: 0 });
+                  }
+                } else if (seg.state === 0 && dur < 60) {
+                  // Short stop; merge into uptime
+                  if (merged.length && merged[merged.length - 1].state === 1) {
+                    merged[merged.length - 1].end = seg.end;
+                  } else {
+                    merged.push({ start: seg.start, end: seg.end, state: 1 });
+                  }
+                } else {
+                  merged.push({ ...seg });
+                }
+              }
+              // Sum up durations and build events
+              let runSec = 0;
+              let downSec = 0;
+              const dayEvents = [];
+              for (const seg of merged) {
+                const duration = seg.end - seg.start;
+                if (seg.state === 1) runSec += duration;
+                else downSec += duration;
+                dayEvents.push({
+                  start: seg.start,
+                  end: seg.end,
+                  state: seg.state,
+                  startStr: formatTime(seg.start),
+                  endStr: formatTime(seg.end),
+                  durMin: Math.round(duration / 60),
+                });
+              }
+              labels.push(formatDate(dayStart));
+              work.push(parseFloat((runSec / 3600).toFixed(1)));
+              down.push(parseFloat((downSec / 3600).toFixed(1)));
+              events.push(dayEvents);
+            }
+            cb(null, { labels, work, down, events });
+          }
+        );
+      }
+    );
+  }
+}
+
+module.exports = { Agent };


### PR DESCRIPTION
## Summary
- enforce UTC+04:00 timezone and format timestamps
- add logout route and expose product names with chart events
- improve frontend charts with event tooltips and report download button

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a774afb2608328837f92182a995a2e