### PR TITLE
Add report download button and enhance charts

### DIFF
--- a/source/new_project/public/index.html
+++ b/source/new_project/public/index.html
@@ -61,7 +61,7 @@
           responsive: true,
           maintainAspectRatio: false,
           scales: {
-            x: { display: true },
+            x: { type: 'category', display: true, ticks: { autoSkip: false } },
             y: {
               beginAtZero: true,
               title: { display: true, text: 'см/мин' },
@@ -107,13 +107,12 @@
                 afterBody: (items) => {
                   const idx = items[0].dataIndex;
                   const evs = dailyEvents[idx] || [];
-                  return evs.flatMap(ev => {
+                  return evs.map(ev => {
                     const h = Math.floor(ev.durMin / 60);
                     const m = ev.durMin % 60;
-                    if (ev.state === 1) {
-                      return [`Запуск: ${ev.startStr}`, `Работа: ${h} ч ${m} мин`];
-                    }
-                    return [`Остановка: ${ev.startStr}`, `Простой: ${h} ч ${m} мин`];
+                    const action = ev.state === 1 ? 'Запуск' : 'Остановка';
+                    const stateText = ev.state === 1 ? 'Работа' : 'Простой';
+                    return `${action}: ${ev.startStr} — ${stateText}: ${h} ч ${m} мин`;
                   });
                 }
               }


### PR DESCRIPTION
## Summary
- Show hour labels in speed chart using API-provided labels
- Add tooltip on daily chart listing run/stop events
- Add report download button for 30-day Excel report

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a77872db5083288ff7399717e36f29