### PR TITLE
Protect static assets with auth and update default password

### DIFF
--- a/source/new_project/config.js
+++ b/source/new_project/config.js
@@ -8,7 +8,7 @@ module.exports = {
   // User name required to access the dashboard.  A separate password is
   // used for the settings page and must be provided there.
   username: "zavod",
-  // Bcrypt hash of the password.  The default password matches the
-  // original build and may be updated by the operator.
-  passwordHash: "$2b$12$v6Afhzj5VUp7/k3yC469VeWcbfD2ro3y9R9v9bfniTvh1nsuucYOu"
+  // Bcrypt hash of the password.  The default password is
+  // "H0lzH0f2025" and may be updated by the operator.
+  passwordHash: "$2b$12$THUaYiNT7WZgfG/AFHRiBevLzGCtbbGEhONOoGPTHr3PSFaY9Swmq"
 };

--- a/source/new_project/server.js
+++ b/source/new_project/server.js
@@ -172,11 +172,11 @@ app.use(
 
 /**
  * Middleware to enforce authentication for protected routes.  Requests
- * to the login page, static assets, the data ingestion endpoint and
- * health endpoints are permitted without a session.
+ * to the login page, the data ingestion endpoint and health endpoints
+ * are permitted without a session. Static assets require a session.
  */
 function requireAuth(req, res, next) {
-  const openPaths = ['/login', '/public', '/data', '/healthz', '/time'];
+  const openPaths = ['/login', '/data', '/healthz', '/time'];
   if (openPaths.some((p) => req.path === p || req.path.startsWith(p + '/'))) {
     return next();
   }


### PR DESCRIPTION
## Summary
- protect `/public` assets behind session auth
- store bcrypt hash for default password `H0lzH0f2025`

## Testing
- ⚠️ `node server.js` *(fails: SyntaxError in config.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a778645f1083288953dadd260a914d