### PR TITLE
Simplify login authentication

### DIFF
--- a/source/new_project/config.js
+++ b/source/new_project/config.js
@@ -1,14 +1,4 @@
-// Login credentials for the web application.  The username and password
-// are kept separate from runtime settings to avoid accidental changes when
-// editing the configuration from the settings page.  The password is
-// stored as a bcrypt hash and can be updated offline with a tool like
-// `bcryptjs` if needed.
-
 module.exports = {
-  // User name required to access the dashboard.  A separate password is
-  // used for the settings page and must be provided there.
-  username: "zavod",
-  // Bcrypt hash of the password.  The default password is
-  // "H0lzH0f2025" and may be updated by the operator.
-  passwordHash: "$2b$12$THUaYiNT7WZgfG/AFHRiBevLzGCtbbGEhONOoGPTHr3PSFaY9Swmq"
+  username: 'zavod',
+  password: '19910509'
 };

--- a/source/new_project/public/login.html
+++ b/source/new_project/public/login.html
@@ -1,20 +1,10 @@
 <!DOCTYPE html>
-<html lang="ru">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Вход</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-</head>
-<body class="bg-gray-100 min-h-screen flex items-center justify-center">
-  <div class="bg-white p-6 rounded shadow w-80">
-    <h1 class="text-xl font-bold mb-4 text-center">Вход</h1>
-    <form method="post" action="/login" class="space-y-4">
-      <input type="text" name="username" placeholder="Логин" class="w-full border p-2 rounded" required />
-      <input type="password" name="password" placeholder="Пароль" class="w-full border p-2 rounded" required />
-      <label class="flex items-center"><input type="checkbox" name="remember" class="mr-2" />Запомнить меня</label>
-      <button type="submit" class="w-full bg-blue-500 hover:bg-blue-600 text-white py-2 rounded">Войти</button>
+<html>
+  <body>
+    <form method="post" action="/login">
+      <input type="text" name="username" />
+      <input type="password" name="password" />
+      <button type="submit">Login</button>
     </form>
-  </div>
-</body>
+  </body>
 </html>

--- a/source/new_project/server.js
+++ b/source/new_project/server.js
@@ -13,12 +13,11 @@
 process.env.TZ = 'Etc/GMT-4';
 const express = require('express');
 const session = require('express-session');
-const bcrypt = require('bcrypt');
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
 const fs = require('fs');
 const ExcelJS = require('exceljs');
-const { username, passwordHash } = require('./config');
+const { username, password } = require('./config');
 const { Agent } = require('./smartAgent');
 const { generateReport } = require('./report');
 
@@ -198,18 +197,14 @@ app.get('/login', (req, res) => {
 app.post(
   '/login',
   express.urlencoded({ extended: true }),
-  async (req, res) => {
-    try {
-      const { username: u, password, remember } = req.body || {};
-      if (u === username && (await bcrypt.compare(String(password || ''), passwordHash))) {
-        req.session.user = username;
-        if (remember) {
-          req.session.cookie.maxAge = 30 * 86400 * 1000; // 30 days
-        }
-        return res.redirect('/');
+  (req, res) => {
+    const { username: u, password: p, remember } = req.body || {};
+    if (u === username && String(p || '') === password) {
+      req.session.user = username;
+      if (remember) {
+        req.session.cookie.maxAge = 30 * 86400 * 1000; // 30 days
       }
-    } catch (e) {
-      console.error('login error', e);
+      return res.redirect('/');
     }
     res.status(401).send('Unauthorized');
   }


### PR DESCRIPTION
## Summary
- Remove bcrypt dependency and compare credentials directly against configuration values.
- Expose plain username and password in config.js.
- Replace styled login page with a minimal form posting to `/login`.

## Testing
- `npm test` *(fails: Missing script "test")*
- `node server.js &` then `curl -i -d 'username=zavod&password=19910509' http://localhost:3000/login`


------
https://chatgpt.com/codex/tasks/task_b_68a77ec3d1d0832885045a747fd8fed6