### PR TITLE
Enforce session authentication

### DIFF
--- a/server.js
+++ b/server.js
@@ -160,7 +160,11 @@ app.use(
  * to the login page, static assets, the data ingestion endpoint and
  * health endpoints are permitted without a session.
  */
-function requireAuth(req, res, next) { return next(); }
+function requireAuth(req, res, next) {
+  const openPaths = ['/login', '/data', '/healthz'];
+  if (openPaths.includes(req.path) || req.path.startsWith('/public')) {
+    return next();
+  }
   if (req.session && req.session.user === username) {
     return next();
   }
@@ -170,7 +174,9 @@ function requireAuth(req, res, next) { return next(); }
 // -----------------------------------------------------------------------------
 // Authentication routes
 
-app.get('/login', (req, res) => { res.redirect('/'); });
+app.get('/login', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'login.html'));
+});
 
 app.post(
   '/login',
@@ -193,8 +199,7 @@ app.post(
 );
 
 // Apply authentication middleware
-// Authentication disabled
-// app.use(requireAuth);
+app.use(requireAuth);
 
 // -----------------------------------------------------------------------------
 // Static files


### PR DESCRIPTION
## Summary
- implement `requireAuth` middleware with session validation and redirects
- serve login page from `/login`
- enable global authentication enforcement

## Testing
- ⚠️ `npm test` (script missing)

------
https://chatgpt.com/codex/tasks/task_b_68a799f0c6f8832892fc347982b00d59