### PR TITLE
Use consistent GMT-4 timezone across server and reports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9-slim
 
+# Set timezone
+ENV TZ=Etc/GMT-4
+
 # Set working directory
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - data:/app/data
     environment:
-      - TZ=Europe/Amsterdam
+      - TZ=Etc/GMT-4
     restart: unless-stopped
 
 volumes:

--- a/server.js
+++ b/server.js
@@ -10,6 +10,8 @@
  * access the settings page.
  */
 
+process.env.TZ = 'Etc/GMT-4';
+
 const express = require('express');
 const session = require('express-session');
 const bcrypt = require('bcrypt');
@@ -30,6 +32,11 @@ const { Agent } = require('./smartAgent');
 // defaults are returned based on the committed version of config.json.
 
 const SETTINGS_PATH = path.join(__dirname, 'config.json');
+
+function formatLocal(date) {
+  const pad = (n) => n.toString().padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
 
 /**
  * Load settings from disk.  If the settings file does not exist the
@@ -423,7 +430,7 @@ app.get('/report', async (req, res) => {
       ];
       // Helper to add a row to the worksheet
       function addRow(date, ev, whenTs, extra) {
-        const whenStr = new Date(whenTs * 1000).toISOString().replace('T', ' ').substring(0, 19);
+        const whenStr = formatLocal(new Date(whenTs * 1000));
         ws.addRow({ date, ev, when: whenStr, downtime: extra });
       }
       // Determine the state at fromTs
@@ -453,7 +460,7 @@ app.get('/report', async (req, res) => {
       let prevState = initial;
       for (let dayStart = Math.floor(fromTs / 86400) * 86400; dayStart < toTs; dayStart += 86400) {
         const dayEnd = Math.min(dayStart + 86400, toTs);
-        const dayLabel = new Date(dayStart * 1000).toISOString().slice(0, 10);
+        const dayLabel = formatLocal(new Date(dayStart * 1000)).slice(0, 10);
         // Build raw segments for this day
         const dayEvents = logs.filter((ev) => ev.timestamp >= dayStart && ev.timestamp < dayEnd);
         let state = prevState;

--- a/smartAgent.js
+++ b/smartAgent.js
@@ -12,6 +12,11 @@
 
 const sqlite3 = require('sqlite3').verbose();
 
+function formatLocal(date) {
+  const pad = (n) => n.toString().padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
 class Agent {
   /**
    * Construct a new Agent.
@@ -281,7 +286,7 @@ class Agent {
         const labels = [];
         const data = [];
         for (let t = fromMinute; t <= toMinute; t += 60) {
-          labels.push(new Date(t * 1000).toISOString());
+          labels.push(formatLocal(new Date(t * 1000)));
           if (map.hasOwnProperty(t)) data.push(map[t]);
           else data.push(null);
         }
@@ -374,7 +379,7 @@ class Agent {
                 if (seg.state === 1) runSec += duration;
                 else downSec += duration;
               }
-              labels.push(new Date(dayStart * 1000).toISOString().slice(0, 10));
+              labels.push(formatLocal(new Date(dayStart * 1000)).slice(0, 10));
               work.push(parseFloat((runSec / 3600).toFixed(1)));
               down.push(parseFloat((downSec / 3600).toFixed(1)));
             }


### PR DESCRIPTION
## Summary
- Set server and container timezone to `Etc/GMT-4`
- Replace all `toISOString()` calls with a local `YYYY-MM-DD HH:mm` formatter
- Apply the formatter to chart data and Excel report generation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a799f3e2c8832898bedb00326524d4