### PR TITLE
Format chart series labels and expose status events

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Монитор линий</title>
+  <!-- Tailwind for quick styling -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Chart.js for graphs -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="bg-gray-100 text-gray-900 min-h-screen">
+  <div id="app" class="p-4">
+    <div class="flex flex-col md:flex-row gap-4">
+      <!-- Left column: list of lines and settings button -->
+      <div class="w-full md:w-1/4">
+        <h2 class="text-lg font-bold mb-2">Линии</h2>
+        <div id="linesList" class="flex flex-col gap-2"></div>
+        <button id="settingsBtn" class="mt-4 px-3 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded">Настройки</button>
+      </div>
+      <!-- Right column: charts -->
+      <div class="flex-1">
+        <h2 id="lineTitle" class="text-lg font-bold mb-2">Скорость</h2>
+        <div class="bg-white p-4 rounded shadow">
+          <canvas id="speedChart"></canvas>
+        </div>
+        <h2 class="text-lg font-bold mt-6 mb-2">Работа / Простой (30 дней)</h2>
+        <div class="bg-white p-4 rounded shadow">
+          <canvas id="dailyChart"></canvas>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    let currentLine = null;
+    let speedChart = null;
+    let dailyChart = null;
+
+    // Create charts on first load
+    function createCharts() {
+      const ctx1 = document.getElementById('speedChart').getContext('2d');
+      speedChart = new Chart(ctx1, {
+        type: 'line',
+        data: {
+          labels: [],
+          datasets: [
+            {
+              label: 'Скорость (см/мин)',
+              data: [],
+              borderColor: '#2563eb',
+              backgroundColor: 'rgba(37, 99, 235, 0.2)',
+              pointRadius: 0,
+              fill: true,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: {
+            x: { display: false },
+            y: {
+              beginAtZero: true,
+              title: { display: true, text: 'см/мин' },
+            },
+          },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                title: (items) => items[0].label,
+              },
+            },
+          },
+        },
+      });
+      const ctx2 = document.getElementById('dailyChart').getContext('2d');
+      dailyChart = new Chart(ctx2, {
+        type: 'bar',
+        data: {
+          labels: [],
+          datasets: [
+            {
+              label: 'Работа (ч)',
+              data: [],
+              backgroundColor: '#16a34a',
+            },
+            {
+              label: 'Простой (ч)',
+              data: [],
+              backgroundColor: '#dc2626',
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: {
+            x: { stacked: true },
+            y: {
+              stacked: true,
+              beginAtZero: true,
+              title: { display: true, text: 'Часы' },
+            },
+          },
+        },
+      });
+    }
+
+    // Load the current status for all lines and populate the list
+    async function loadStatus() {
+      try {
+        const res = await fetch('/status');
+        const lines = await res.json();
+        const container = document.getElementById('linesList');
+        container.innerHTML = '';
+        lines.forEach((item) => {
+          const div = document.createElement('div');
+          div.className = 'p-2 bg-white rounded shadow flex justify-between items-center cursor-pointer';
+          div.dataset.lineId = item.lineId;
+          const name = item.displayName || item.lineId;
+          const stateLabel = item.stateLabel;
+          const speed = (item.speed && !isNaN(item.speed)) ? item.speed.toFixed(1) : '-';
+          const product = item.product || '';
+          div.innerHTML = `
+            <div>
+              <div class="font-semibold">${name}</div>
+              <div class="text-sm text-gray-500">${stateLabel}</div>
+              <div class="text-xs text-gray-400">Изделие: ${product || '-'}</div>
+            </div>
+            <div class="text-right">
+              <div class="font-mono">${speed}</div>
+            </div>
+          `;
+          div.addEventListener('click', () => {
+            selectLine(item.lineId);
+          });
+          if (currentLine === null) {
+            currentLine = item.lineId;
+          }
+          container.appendChild(div);
+        });
+        // Highlight the selected line
+        Array.from(container.children).forEach((child) => {
+          child.classList.remove('border', 'border-blue-500');
+          if (child.dataset.lineId === currentLine) {
+            child.classList.add('border', 'border-blue-500');
+          }
+        });
+      } catch (e) {
+        console.error('loadStatus', e);
+      }
+    }
+
+    // Change the selected line and refresh charts
+    async function selectLine(lineId) {
+      currentLine = lineId;
+      await updateCharts();
+      // update highlight
+      const container = document.getElementById('linesList');
+      Array.from(container.children).forEach((child) => {
+        child.classList.remove('border', 'border-blue-500');
+        if (child.dataset.lineId === lineId) {
+          child.classList.add('border', 'border-blue-500');
+        }
+      });
+    }
+
+    // Fetch chart data for the current line and update both charts
+    async function updateCharts() {
+      if (!currentLine) return;
+      try {
+        const res = await fetch('/chartdata/' + currentLine);
+        const data = await res.json();
+        // Speed chart: labels are already formatted as YYYY-MM-DD HH:mm
+        speedChart.data.labels = data.speed.labels;
+        speedChart.data.datasets[0].data = data.speed.data;
+        speedChart.update();
+        // Daily chart
+        dailyChart.data.labels = data.status.labels;
+        dailyChart.data.datasets[0].data = data.status.work;
+        dailyChart.data.datasets[1].data = data.status.down;
+        dailyChart.update();
+        document.getElementById('lineTitle').textContent = `${data.status.lineName || currentLine} — скорость`;
+      } catch (e) {
+        console.error('updateCharts', e);
+      }
+    }
+
+    // Periodically refresh status and charts
+    async function periodic() {
+      await loadStatus();
+      await updateCharts();
+      setTimeout(periodic, 15000);
+    }
+
+    window.addEventListener('DOMContentLoaded', () => {
+      createCharts();
+      loadStatus().then(() => {
+        selectLine(currentLine);
+      });
+      periodic();
+      document.getElementById('settingsBtn').addEventListener('click', () => {
+        window.location.href = '/settings';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -354,6 +354,9 @@ app.get('/status', (req, res) => {
 app.get('/chartdata/:lineId', (req, res) => {
   const lineId = String(req.params.lineId || '').trim();
   const hours = Number(settings.graphHours) || 24;
+  const now = Math.floor(Date.now() / 1000);
+  const toMinute = Math.floor(now / 60) * 60;
+  const fromMinute = toMinute - hours * 3600;
   agent.getSeries(lineId, hours, (err1, series) => {
     if (err1 || !series) {
       console.error('getSeries', err1);
@@ -364,18 +367,25 @@ app.get('/chartdata/:lineId', (req, res) => {
         console.error('getDailyWorkIdle', err2);
         return res.status(500).json({ error: 'daily' });
       }
-      const lineName = (settings.lineNames && settings.lineNames[lineId]) || lineId;
-      const speed = {
-        labels: series.labels,
-        data: series.data,
-      };
-      const status = {
-        labels: daily.labels,
-        work: daily.work,
-        down: daily.down,
-        lineName,
-      };
-      res.json({ speed, status });
+      agent.getEvents(lineId, fromMinute, toMinute, (err3, events) => {
+        if (err3 || !events) {
+          console.error('getEvents', err3);
+          return res.status(500).json({ error: 'events' });
+        }
+        const lineName = (settings.lineNames && settings.lineNames[lineId]) || lineId;
+        const speed = {
+          labels: series.labels,
+          data: series.data,
+        };
+        const status = {
+          labels: daily.labels,
+          work: daily.work,
+          down: daily.down,
+          lineName,
+          events,
+        };
+        res.json({ speed, status });
+      });
     });
   });
 });

--- a/smartAgent.js
+++ b/smartAgent.js
@@ -12,6 +12,13 @@
 
 const sqlite3 = require('sqlite3').verbose();
 
+// Format a UNIX timestamp (seconds) as 'YYYY-MM-DD HH:mm'.
+function fmt(ts) {
+  const d = new Date(ts * 1000);
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 class Agent {
   /**
    * Construct a new Agent.
@@ -281,7 +288,7 @@ class Agent {
         const labels = [];
         const data = [];
         for (let t = fromMinute; t <= toMinute; t += 60) {
-          labels.push(new Date(t * 1000).toISOString());
+          labels.push(fmt(t));
           if (map.hasOwnProperty(t)) data.push(map[t]);
           else data.push(null);
         }
@@ -379,6 +386,74 @@ class Agent {
               down.push(parseFloat((downSec / 3600).toFixed(1)));
             }
             cb(null, { labels, work, down });
+          }
+        );
+      }
+    );
+  }
+
+  /**
+   * Retrieve merged RUN/STOP segments within a time window.  Short
+   * segments (<60s) are folded into the surrounding state to eliminate
+   * spurious toggles.
+   *
+   * @param {String} lineId Identifier of the line.
+   * @param {Number} from   Start timestamp in seconds (inclusive).
+   * @param {Number} to     End timestamp in seconds (inclusive).
+   * @param {Function} cb   Callback (err, events).
+   */
+  getEvents(lineId, from, to, cb) {
+    this.db.all(
+      `SELECT timestamp, isRunning FROM status_log WHERE lineId=? AND timestamp>=? AND timestamp<=? ORDER BY timestamp ASC`,
+      [lineId, from, to],
+      (err, rows) => {
+        if (err) return cb(err);
+        this.db.get(
+          `SELECT isRunning FROM status_log WHERE lineId=? AND timestamp<? ORDER BY timestamp DESC LIMIT 1`,
+          [lineId, from],
+          (err2, lastRow) => {
+            if (err2) return cb(err2);
+            let state = lastRow ? Number(lastRow.isRunning) : 0;
+            let start = from;
+            const segments = [];
+            for (const r of rows) {
+              const s = Number(r.isRunning);
+              if (s !== state) {
+                segments.push({ start, end: r.timestamp, state });
+                state = s;
+                start = r.timestamp;
+              }
+            }
+            segments.push({ start, end: to, state });
+            // Merge short segments (<60s)
+            const merged = [];
+            for (const seg of segments) {
+              const dur = seg.end - seg.start;
+              if (seg.state === 1 && dur < 60) {
+                if (merged.length && merged[merged.length - 1].state === 0) {
+                  merged[merged.length - 1].end = seg.end;
+                } else {
+                  merged.push({ start: seg.start, end: seg.end, state: 0 });
+                }
+              } else if (seg.state === 0 && dur < 60) {
+                if (merged.length && merged[merged.length - 1].state === 1) {
+                  merged[merged.length - 1].end = seg.end;
+                } else {
+                  merged.push({ start: seg.start, end: seg.end, state: 1 });
+                }
+              } else {
+                merged.push({ ...seg });
+              }
+            }
+            const events = merged.map((seg) => ({
+              start: seg.start,
+              end: seg.end,
+              state: seg.state,
+              startStr: fmt(seg.start),
+              endStr: fmt(seg.end),
+              durMin: parseFloat(((seg.end - seg.start) / 60).toFixed(1)),
+            }));
+            cb(null, events);
           }
         );
       }


### PR DESCRIPTION
## Summary
- format time-series labels as `YYYY-MM-DD HH:mm`
- include merged run/stop segments in `/chartdata/:lineId`
- show formatted labels directly in chart UI

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a799f4aff48328a4f6848660e697a3