### PR TITLE
Fix date formatting helper in smartAgent

### DIFF
--- a/smartAgent.js
+++ b/smartAgent.js
@@ -17,6 +17,8 @@ function fmt(ts) {
   const d = new Date(ts * 1000);
   const pad = (n) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 function formatLocal(date) {
   const pad = (n) => n.toString().padStart(2, '0');
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;


### PR DESCRIPTION
## Summary
- close fmt helper properly and add standalone `formatLocal`
- remove stray brace at file end

## Testing
- `node --check smartAgent.js`


------
https://chatgpt.com/codex/tasks/task_b_68a7f17b4c688328b30c94660cf152b2