### PR TITLE
Use local time labels in series generation

### DIFF
--- a/smartAgent.js
+++ b/smartAgent.js
@@ -17,6 +17,8 @@ function fmt(ts) {
   const d = new Date(ts * 1000);
   const pad = (n) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 function formatLocal(date) {
   const pad = (n) => n.toString().padStart(2, '0');
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
@@ -291,7 +293,6 @@ class Agent {
         const labels = [];
         const data = [];
         for (let t = fromMinute; t <= toMinute; t += 60) {
-          labels.push(fmt(t));
           labels.push(formatLocal(new Date(t * 1000)));
           if (map.hasOwnProperty(t)) data.push(map[t]);
           else data.push(null);


### PR DESCRIPTION
## Summary
- ensure date label formatting uses `formatLocal` helper
- simplify `getSeries` loop to push a single local label per minute

## Testing
- `node --check smartAgent.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a7f17b71f48328bca73d75ce34b2a6