### PR TITLE
Remove enabledLines configuration and related logic

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,21 +21,6 @@
     "line12": "Линия 12",
     "line13": "Линия 13"
   },
-  "enabledLines": [
-    "line1",
-    "line2",
-    "line3",
-    "line4",
-    "line5",
-    "line6",
-    "line7",
-    "line8",
-    "line9",
-    "line10",
-    "line11",
-    "line12",
-    "line13"
-  ],
   "settingsPassword": "19910509",
   "products": {
     "line1": "",

--- a/config.schema.json
+++ b/config.schema.json
@@ -43,11 +43,6 @@
       "description": "Display names for the 13 lines",
       "additionalProperties": { "type": "string" }
     },
-    "enabledLines": {
-      "type": "array",
-      "description": "Lines included in processing; inactive lines still appear in the UI",
-      "items": { "type": "string" }
-    },
     "settingsPassword": {
       "type": "string",
       "description": "Password required to authorise changes via the settings page"

--- a/server.js
+++ b/server.js
@@ -676,11 +676,6 @@ app.post('/settings/save', (req, res) => {
     newCfg.delayStop = num(body.delayStop, settings.delayStop);
     newCfg.graphHours = num(body.graphHours, settings.graphHours);
     newCfg.offlineTimeout = num(body.offlineTimeout, settings.offlineTimeout);
-    // Enabled lines should be an array of strings; if omitted use
-    // existing enabledLines.
-    if (Array.isArray(body.enabledLines)) {
-      newCfg.enabledLines = body.enabledLines.map((x) => String(x));
-    }
     // lineNames is expected to be an object mapping lineId to string
     if (body.lineNames && typeof body.lineNames === 'object') {
       const names = {};

--- a/server.py
+++ b/server.py
@@ -679,8 +679,6 @@ class Handler(BaseHTTPRequestHandler):
         gh = int(to_num(data.get('graphHours'), settings.get('graphHours', 24)))
         new_cfg['graphHours'] = gh if gh in (24, 48) else settings.get('graphHours', 24)
         new_cfg['offlineTimeout'] = int(to_num(data.get('offlineTimeout'), settings.get('offlineTimeout', 60)))
-        if isinstance(data.get('enabledLines'), list):
-            new_cfg['enabledLines'] = [str(x) for x in data.get('enabledLines')]
         if isinstance(data.get('lineNames'), dict):
             names = {}
             for i in range(1, 14):


### PR DESCRIPTION
## Summary
- Drop legacy `enabledLines` from both configuration files.
- Remove save-route logic for `enabledLines` in Node and Python servers.

## Testing
- `python -m py_compile server.py`
- `node --check server.js` *(fails: await is only valid in async functions and the top level bodies of modules)*

------
https://chatgpt.com/codex/tasks/task_b_68a7f17dc2f483288fad8de279496807