### PR TITLE
Improve chart data timezone handling and settings UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,7 @@
         <h2 class="text-lg font-bold mt-6 mb-2">Работа / Простой (30 дней)</h2>
         <div class="bg-white p-4 rounded shadow">
           <canvas id="dailyChart"></canvas>
+          <button id="reportBtn" class="mt-4 px-3 py-2 bg-green-500 hover:bg-green-600 text-white rounded">Скачать отчёт за 30 дней</button>
         </div>
       </div>
     </div>
@@ -36,6 +37,7 @@
     let currentLine = null;
     let speedChart = null;
     let dailyChart = null;
+    let dailyEvents = {};
 
     // Create charts on first load
     function createCharts() {
@@ -59,7 +61,12 @@
           responsive: true,
           maintainAspectRatio: false,
           scales: {
-            x: { display: false },
+            x: {
+              display: true,
+              ticks: {
+                callback: (val, idx) => speedChart.data.labels[idx]?.slice(11) || '',
+              },
+            },
             y: {
               beginAtZero: true,
               title: { display: true, text: 'см/мин' },
@@ -102,6 +109,30 @@
               stacked: true,
               beginAtZero: true,
               title: { display: true, text: 'Часы' },
+            },
+          },
+          plugins: {
+            tooltip: {
+              callbacks: {
+                label: (ctx) => `${ctx.dataset.label}: ${ctx.formattedValue}`,
+                afterBody: (items) => {
+                  const day = items[0].label;
+                  const evs = dailyEvents[day] || [];
+                  const lines = [];
+                  evs.forEach((ev) => {
+                    const h = Math.floor(ev.durMin / 60);
+                    const m = Math.round(ev.durMin % 60);
+                    if (ev.state === 0) {
+                      lines.push(`Остановка: ${ev.startStr}`);
+                      lines.push(`Простой: ${h ? h + ' ч ' : ''}${m} мин`);
+                    } else {
+                      lines.push(`Запуск: ${ev.startStr}`);
+                      lines.push(`Работа: ${h ? h + ' ч ' : ''}${m} мин`);
+                    }
+                  });
+                  return lines;
+                },
+              },
             },
           },
         },
@@ -181,6 +212,7 @@
         dailyChart.data.labels = data.status.labels;
         dailyChart.data.datasets[0].data = data.status.work;
         dailyChart.data.datasets[1].data = data.status.down;
+        dailyEvents = data.status.events || {};
         dailyChart.update();
         document.getElementById('lineTitle').textContent = `${data.status.lineName || currentLine} — скорость`;
       } catch (e) {
@@ -203,6 +235,9 @@
       periodic();
       document.getElementById('settingsBtn').addEventListener('click', () => {
         window.location.href = '/settings';
+      });
+      document.getElementById('reportBtn').addEventListener('click', () => {
+        window.location.href = '/report';
       });
     });
   </script>

--- a/public/settings.html
+++ b/public/settings.html
@@ -9,14 +9,27 @@
 <body>
   <h1>Settings</h1>
   <div id="auth-section">
-    <p>Enter settings password:</p>
+    <p>Введите пароль настроек:</p>
     <input type="password" id="settings-password" />
-    <button id="auth-button">Unlock</button>
+    <button id="auth-button">Открыть</button>
     <p id="auth-status"></p>
   </div>
+  <div id="settings-form" style="display:none">
+    <h2>Параметры</h2>
+    <label>Окно усреднения (сек): <input type="number" id="windowSec" /></label><br/>
+    <label>V_START: <input type="number" id="V_START" step="0.1" /></label><br/>
+    <label>V_STOP: <input type="number" id="V_STOP" step="0.1" /></label><br/>
+    <label>delayStart (сек): <input type="number" id="delayStart" /></label><br/>
+    <label>delayStop (сек): <input type="number" id="delayStop" /></label><br/>
+    <label>graphHours: <input type="number" id="graphHours" /></label><br/>
+    <label>offlineTimeout: <input type="number" id="offlineTimeout" /></label><br/>
+    <h3>Названия линий</h3>
+    <div id="lineNames"></div>
+    <button id="save-button">Сохранить</button>
+    <p id="save-status"></p>
+  </div>
   <script>
-    const btn = document.getElementById('auth-button');
-    btn.addEventListener('click', async () => {
+    async function unlock() {
       const password = document.getElementById('settings-password').value;
       try {
         const res = await fetch('/settings/auth', {
@@ -25,11 +38,74 @@
           body: JSON.stringify({ password })
         });
         const data = await res.json();
-        document.getElementById('auth-status').textContent = data && data.ok ? 'Authenticated' : 'Access denied';
+        if (data && data.ok) {
+          document.getElementById('auth-section').style.display = 'none';
+          loadSettings();
+        } else {
+          document.getElementById('auth-status').textContent = 'Доступ запрещён';
+        }
       } catch (err) {
-        document.getElementById('auth-status').textContent = 'Error contacting server';
+        document.getElementById('auth-status').textContent = 'Ошибка соединения';
       }
-    });
+    }
+
+    async function loadSettings() {
+      try {
+        const res = await fetch('/settings/info');
+        const data = await res.json();
+        document.getElementById('windowSec').value = data.windowSec || 0;
+        document.getElementById('V_START').value = data.V_START || 0;
+        document.getElementById('V_STOP').value = data.V_STOP || 0;
+        document.getElementById('delayStart').value = data.delayStart || 0;
+        document.getElementById('delayStop').value = data.delayStop || 0;
+        document.getElementById('graphHours').value = data.graphHours || 24;
+        document.getElementById('offlineTimeout').value = data.offlineTimeout || 0;
+        const container = document.getElementById('lineNames');
+        container.innerHTML = '';
+        if (data.lineNames) {
+          for (let i = 1; i <= 13; i++) {
+            const id = `line${i}`;
+            const div = document.createElement('div');
+            div.innerHTML = `${id}: <input type="text" id="name_${id}" value="${data.lineNames[id] || ''}">`;
+            container.appendChild(div);
+          }
+        }
+        document.getElementById('settings-form').style.display = 'block';
+      } catch (err) {
+        document.getElementById('auth-status').textContent = 'Не удалось загрузить настройки';
+      }
+    }
+
+    async function saveSettings() {
+      const payload = {
+        windowSec: Number(document.getElementById('windowSec').value),
+        V_START: Number(document.getElementById('V_START').value),
+        V_STOP: Number(document.getElementById('V_STOP').value),
+        delayStart: Number(document.getElementById('delayStart').value),
+        delayStop: Number(document.getElementById('delayStop').value),
+        graphHours: Number(document.getElementById('graphHours').value),
+        offlineTimeout: Number(document.getElementById('offlineTimeout').value),
+        lineNames: {}
+      };
+      for (let i = 1; i <= 13; i++) {
+        const id = `line${i}`;
+        payload.lineNames[id] = document.getElementById(`name_${id}`).value;
+      }
+      try {
+        const res = await fetch('/settings/save', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const data = await res.json();
+        document.getElementById('save-status').textContent = data && data.ok ? 'Сохранено' : 'Ошибка';
+      } catch (err) {
+        document.getElementById('save-status').textContent = 'Ошибка сохранения';
+      }
+    }
+
+    document.getElementById('auth-button').addEventListener('click', unlock);
+    document.getElementById('save-button').addEventListener('click', saveSettings);
   </script>
 </body>
 </html>

--- a/smartAgent.js
+++ b/smartAgent.js
@@ -12,13 +12,6 @@
 
 const sqlite3 = require('sqlite3').verbose();
 
-// Format a UNIX timestamp (seconds) as 'YYYY-MM-DD HH:mm'.
-function fmt(ts) {
-  const d = new Date(ts * 1000);
-  const pad = (n) => String(n).padStart(2, '0');
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
-
 function formatLocal(date) {
   const pad = (n) => n.toString().padStart(2, '0');
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
@@ -454,8 +447,8 @@ class Agent {
               start: seg.start,
               end: seg.end,
               state: seg.state,
-              startStr: fmt(seg.start),
-              endStr: fmt(seg.end),
+              startStr: formatLocal(new Date(seg.start * 1000)).slice(11),
+              endStr: formatLocal(new Date(seg.end * 1000)).slice(11),
               durMin: parseFloat(((seg.end - seg.start) / 60).toFixed(1)),
             }));
             cb(null, events);


### PR DESCRIPTION
## Summary
- format chart timestamps in UTC+04 and expose daily events for 30 days
- show hourly labels and per-day tooltips in charts with report download button
- add working settings page to view and update runtime parameters

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_b_68a7926359ec8328854d95144337bef1